### PR TITLE
statistical-test: Goodness of fit.

### DIFF
--- a/lib/statistics/statistical_test/chi_squared_test.rb
+++ b/lib/statistics/statistical_test/chi_squared_test.rb
@@ -1,0 +1,42 @@
+module Statistics
+  module StatisticalTest
+    class ChiSquaredTest
+      def self.chi_statistic(expected, observed)
+        # If the expected is a number, we asumme that all expected observations
+        # has the same probability to occur, hence we expect to see the same number
+        # of expected observations per each observed value
+        statistic = if expected.is_a? Numeric
+                      observed.reduce(0) do |memo, observed_value|
+                        up = (observed_value - expected) ** 2
+                        memo += (up/expected.to_f)
+                      end
+                    else
+                      expected.each_with_index.reduce(0) do |memo, (expected_value, index)|
+                        up = (observed[index] - expected_value) ** 2
+                        memo += (up/expected_value.to_f)
+                      end
+                    end
+
+          [statistic, observed.size - 1]
+      end
+
+      def self.goodness_of_fit(alpha, expected, observed)
+        chi_score, df = *self.chi_statistic(expected, observed) # Splat array result
+
+        return if chi_score.nil? || df.nil?
+
+        probability = Distribution::ChiSquared.new(df).cumulative_function(chi_score)
+        p_value = 1 - probability
+
+        # According to https://stats.stackexchange.com/questions/29158/do-you-reject-the-null-hypothesis-when-p-alpha-or-p-leq-alpha
+        # We can assume that if p_value <= alpha, we can safely reject the null hypothesis, ie. accept the alternative hypothesis.
+        { probability: probability,
+          p_value: p_value,
+          alpha: alpha,
+          null: alpha < p_value,
+          alternative: p_value <= alpha,
+          confidence_level: 1 - alpha }
+      end
+    end
+  end
+end

--- a/spec/statistics/statistical_test/chi_squared_test_spec.rb
+++ b/spec/statistics/statistical_test/chi_squared_test_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe Statistics::StatisticalTest::ChiSquaredTest do
+  describe '.chi_statistic' do
+    # example ONE
+    # explained here: https://www.thoughtco.com/chi-square-goodness-of-fit-test-example-3126382
+    it 'returns an array with expected chi-squared statistic value following example ONE' do
+      observed_counts = [212, 147, 103, 50, 46, 42]
+      expected = 100
+      result = described_class.chi_statistic(expected, observed_counts)
+      expect(result[0].round(3)).to eq 235.42
+    end
+
+    it 'returns an array with the expected degrees of freedom following example ONE' do
+      observed_counts = [212, 147, 103, 50, 46, 42]
+      expected = 100
+      result = described_class.chi_statistic(expected, observed_counts)
+      degrees_of_freedom = observed_counts.size - 1
+
+      expect(result[1]).to eq degrees_of_freedom
+    end
+
+    # Example two: chocolate colours
+    # explained here: https://onlinecourses.science.psu.edu/stat414/book/export/html/228
+    it 'returns an array with the expected chi-squared statistic value following example TWO' do
+      observed = [224, 119, 130, 48, 59]
+      expected = [232, 116, 116, 58, 58]
+
+      result = described_class.chi_statistic(expected, observed)
+
+      expect(result[0].round(3)).to eq 3.784
+    end
+
+    it 'returns an array with the expected degrees of freedom following example TWO' do
+      observed = [224, 119, 130, 48, 59]
+      expected = [232, 116, 116, 58, 58]
+
+      result = described_class.chi_statistic(expected, observed)
+      degrees_of_freedom = observed.size - 1
+
+      expect(result[1]).to eq degrees_of_freedom
+    end
+  end
+
+  describe '.goodness_of_fit' do
+    it 'perform a goodness of fit test following example ONE' do
+      observed_counts = [212, 147, 103, 50, 46, 42]
+      expected = 100
+      result = described_class.goodness_of_fit(0.05, expected, observed_counts)
+
+      expect(result[:p_value]).to eq -6.533440455314121e-12
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+    end
+
+    it 'perform a goodness of fit test following example TWO' do
+      observed = [224, 119, 130, 48, 59]
+      expected = [232, 116, 116, 58, 58]
+
+      result = described_class.goodness_of_fit(0.05, expected, observed)
+
+      expect(result[:p_value]).to eq 0.43594838428718374
+      expect(result[:null]).to be true
+      expect(result[:alternative]).to be false
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** _#7_

One of the tasks in #7.

I made some benchmark and this are the results.
Made in opensuse Leap 43.2 with Pentium Dual-Core T4300 @ 2.10Ghz 1024 kb Cache size.
```ruby
require 'benchmark'
Benchmark.bm do |x|
  x.report('100:') { StatisticalTest::ChiSquaredTest.goodness_of_fit(0.05, (1..100).to_a, (1..100).to_a) }
  x.report('10_000:') { StatisticalTest::ChiSquaredTest.goodness_of_fit(0.05, (1..10_000).to_a, (1..10_000).to_a) }
  x.report('1_000_000:') { StatisticalTest::ChiSquaredTest.goodness_of_fit(0.05, (1..1_000_000).to_a, (1..1_000_000).to_a) }
  x.report('100_000_000:') { StatisticalTest::ChiSquaredTest.goodness_of_fit(0.05, (1..100_000_000).to_a, (1..100_000_000).to_a) }
end
       user     system      total        real
100:  0.000000   0.000000   0.000000 (  0.000359)
10_000:  0.020000   0.000000   0.020000 (  0.017709)
1_000_000:  0.630000   0.000000   0.630000 (  0.637986)
100_000_000: 61.610000   1.020000  62.630000 ( 62.910888)
```