### PR TITLE
Issue-13: "p-values for T-test are not accurate enough"

### DIFF
--- a/lib/enumerable.rb
+++ b/lib/enumerable.rb
@@ -1,0 +1,15 @@
+# TODO: Avoid monkey-patching.
+module Enumerable
+  def mean
+    self.reduce(:+) / self.length.to_f
+  end
+
+  def variance
+    mean = self.mean
+    self.reduce(0) { |memo, value| memo + ((value - mean) ** 2) } / (self.length - 1).to_f
+  end
+
+  def standard_deviation
+    Math.sqrt(self.variance)
+  end
+end

--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -1,5 +1,4 @@
-require 'descriptive_statistics'
-
+require File.dirname(__FILE__) + '/enumerable'
 require File.dirname(__FILE__) + '/math'
 Dir[ File.dirname(__FILE__) + '/statistics/**/*.rb'].each {|file| require file }
 

--- a/lib/statistics/version.rb
+++ b/lib/statistics/version.rb
@@ -1,3 +1,3 @@
 module Statistics
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/ruby-statistics.gemspec
+++ b/ruby-statistics.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", '>= 3.6.0'
   spec.add_development_dependency "grb", '0.4.1'
   spec.add_development_dependency 'byebug', '9.1.0'
-  spec.add_dependency 'descriptive_statistics', '2.5.1'
 end

--- a/spec/statistics/enumerable_spec.rb
+++ b/spec/statistics/enumerable_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Enumerable do
+  describe '#mean' do
+    it 'calculates the mean of an specific collection' do
+      expect((1..5).to_a.mean).to eq 3.0
+      expect((1..10).to_a.mean).to eq 5.5
+      expect((-10..-5).to_a.mean).to eq -7.5
+    end
+  end
+
+  describe '#variance' do
+    it 'calculates the *sample* variance of an specific collection' do
+      expect((1..5).to_a.variance).to eq 2.5
+      expect((1..10).to_a.variance).to eq 9.166666666666666
+      expect((-10..-5).to_a.variance).to eq 3.5
+    end
+  end
+
+  describe '#standard_deviation' do
+    it 'calcultes the *sample* standard deviation of an specific collection' do
+      expect((1..5).to_a.standard_deviation).to eq 1.5811388300841898
+      expect((1..10).to_a.standard_deviation).to eq 3.0276503540974917
+      expect((-10..-5).to_a.standard_deviation).to eq 1.8708286933869707
+    end
+  end
+end

--- a/spec/statistics/statistical_test/t_test_spec.rb
+++ b/spec/statistics/statistical_test/t_test_spec.rb
@@ -85,10 +85,7 @@ describe Statistics::StatisticalTest::TTest do
 
       result = described_class.paired_test(alpha, :one_tail, before, after)
 
-      # https://github.com/estebanz01/ruby-statistics/issues/13
-      # In the example, the p-value for one-side is 0.0006 but we have 0.0004
-      # Apparently, it's how ruby handles and calculates the float points
-      # expect(result[:p_value]).to eq 0.0006
+      expect(result[:p_value].round(4)).to eq 0.0006
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
     end
@@ -100,10 +97,7 @@ describe Statistics::StatisticalTest::TTest do
 
       result = described_class.paired_test(alpha, :two_tail, before, after)
 
-      # https://github.com/estebanz01/ruby-statistics/issues/13
-      # In the example, the p-value for one-side is 0.0012 but we have 0.0008
-      # Apparently, it's how ruby handles and calculates the float points
-      # expect(result[:p_value].round(4)).to eq 0.0012
+      expect(result[:p_value].round(4)).to eq 0.0012
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
     end
@@ -123,10 +117,7 @@ describe Statistics::StatisticalTest::TTest do
 
       result = described_class.paired_test(alpha, :two_tail, five_mts, ten_mts)
 
-      # https://github.com/estebanz01/ruby-statistics/issues/13
-      # In the example, the p-value for one-side is 0.0026 but we have 0.0024
-      # Apparently, it's how ruby handles and calculates the float points
-      # expect(result[:p_value].round(3)).to eq 0.026
+      expect(result[:p_value].round(3)).to eq 0.026
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
     end

--- a/spec/statistics/statistical_test/wilcoxon_rank_sum_test_spec.rb
+++ b/spec/statistics/statistical_test/wilcoxon_rank_sum_test_spec.rb
@@ -70,6 +70,7 @@ describe Statistics::StatisticalTest::WilcoxonRankSumTest do
       expect(result[:z].round(3)).to eq -0.186
       expect(result[:null]).to be true
       expect(result[:alternative]).to be false
+      expect(result[:p_value]).to eq 0.8525013990549617
     end
 
     it 'performs a wilcoxon rank sum/Mann-Whitney U test following example THREE' do
@@ -82,6 +83,7 @@ describe Statistics::StatisticalTest::WilcoxonRankSumTest do
       expect(result[:z].round(3)).to eq -2.988
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
+      expect(result[:p_value]).to eq 0.002808806689028387
     end
   end
 end


### PR DESCRIPTION
**Issue:** #13 

We found out that this issue is not related to a ruby float handling, but a different implementation of the variance and standard deviation formulas in `descriptive_statistics`. This PR removes that dependency 😀 .