### PR TITLE
Issue 20: T-Test should tell you when it calculated an std of zero.

### DIFF
--- a/lib/statistics/statistical_test/t_test.rb
+++ b/lib/statistics/statistical_test/t_test.rb
@@ -1,6 +1,11 @@
 module Statistics
   module StatisticalTest
     class TTest
+      # Errors for Zero std
+      class ZeroStdError < StandardError
+        STD_ERROR_MSG = 'Standard deviation for the difference is zero. Please, reconsider sample contents'.freeze
+      end
+
       # Perform a T-Test for one or two samples.
       # For the tails param, we need a symbol: :one_tail or :two_tail
       def self.perform(alpha, tails, *args)
@@ -11,6 +16,10 @@ module Statistics
         t_score = if args[0].is_a? Numeric
                     data_mean = args[1].mean
                     data_std = args[1].standard_deviation
+
+                    puts data_std
+                    raise ZeroStdError.new, ZeroStdError::STD_ERROR_MSG if data_std == 0
+
                     comparison_mean = args[0]
                     degrees_of_freedom = args[1].size
 
@@ -43,11 +52,17 @@ module Statistics
       end
 
       def self.paired_test(alpha, tails, left_group, right_group)
+        raise StandardError.new('both samples are the same') if left_group == right_group
+
         # Handy snippet grabbed from https://stackoverflow.com/questions/2682411/ruby-sum-corresponding-members-of-two-or-more-arrays
         differences = [left_group, right_group].transpose.map { |value| value.reduce(:-) }
 
         degrees_of_freedom = differences.size - 1
-        down = differences.standard_deviation/Math.sqrt(differences.size)
+        difference_std = differences.standard_deviation
+
+        raise ZeroStdError.new, ZeroStdError::STD_ERROR_MSG if difference_std == 0
+
+        down = difference_std/Math.sqrt(differences.size)
 
         t_score = (differences.mean - 0)/down.to_f
 

--- a/lib/statistics/statistical_test/t_test.rb
+++ b/lib/statistics/statistical_test/t_test.rb
@@ -3,7 +3,7 @@ module Statistics
     class TTest
       # Errors for Zero std
       class ZeroStdError < StandardError
-        STD_ERROR_MSG = 'Standard deviation for the difference is zero. Please, reconsider sample contents'.freeze
+        STD_ERROR_MSG = 'Standard deviation for the difference or group is zero. Please, reconsider sample contents'.freeze
       end
 
       # Perform a T-Test for one or two samples.
@@ -13,12 +13,12 @@ module Statistics
 
         degrees_of_freedom = 0
 
+        # If the comparison mean has been specified
         t_score = if args[0].is_a? Numeric
                     data_mean = args[1].mean
                     data_std = args[1].standard_deviation
 
-                    puts data_std
-                    raise ZeroStdError.new, ZeroStdError::STD_ERROR_MSG if data_std == 0
+                    raise ZeroStdError, ZeroStdError::STD_ERROR_MSG if data_std == 0
 
                     comparison_mean = args[0]
                     degrees_of_freedom = args[1].size
@@ -52,7 +52,7 @@ module Statistics
       end
 
       def self.paired_test(alpha, tails, left_group, right_group)
-        raise StandardError.new('both samples are the same') if left_group == right_group
+        raise StandardError, 'both samples are the same' if left_group == right_group
 
         # Handy snippet grabbed from https://stackoverflow.com/questions/2682411/ruby-sum-corresponding-members-of-two-or-more-arrays
         differences = [left_group, right_group].transpose.map { |value| value.reduce(:-) }
@@ -60,7 +60,7 @@ module Statistics
         degrees_of_freedom = differences.size - 1
         difference_std = differences.standard_deviation
 
-        raise ZeroStdError.new, ZeroStdError::STD_ERROR_MSG if difference_std == 0
+        raise ZeroStdError, ZeroStdError::STD_ERROR_MSG if difference_std == 0
 
         down = difference_std/Math.sqrt(differences.size)
 

--- a/lib/statistics/version.rb
+++ b/lib/statistics/version.rb
@@ -1,3 +1,3 @@
 module Statistics
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end

--- a/spec/statistics/statistical_test/t_test_spec.rb
+++ b/spec/statistics/statistical_test/t_test_spec.rb
@@ -2,6 +2,20 @@ require 'spec_helper'
 
 describe Statistics::StatisticalTest::TTest do
   describe '.perform' do
+    context 'when there is an standard deviation of zero' do
+      let(:alpha) { 0.05 }
+
+      it 'does not perform a t-test when standard deviation of zero' do
+        sample_1 = [1.0, 1.0, 1.0]
+
+        error_msg = 'Standard deviation for the difference is zero. Please, reconsider sample contents'
+
+        expect do
+          described_class.perform(alpha, :one_tail, sample_1)
+        end.to raise_error(described_class::ZeroStdError,  error_msg)
+      end
+    end
+
     # Example with one sample
     # explained here: https://secure.brightstat.com/index.php?id=40
     # A random sample of 22 fifth grade pupils have a grade point average of 5.0 in maths
@@ -59,6 +73,30 @@ describe Statistics::StatisticalTest::TTest do
   end
 
   describe '.paired_test' do
+    context 'when both samples have an standard deviation of zero' do
+      let(:alpha) { 0.05 }
+
+      it 'does not perform a paired test when both samples are the same' do
+        sample_1 = [1.0, 2.0]
+        sample_2 = sample_1
+
+        expect do
+          described_class.paired_test(alpha, :one_tail, sample_1, sample_2)
+        end.to raise_error(StandardError, 'both samples are the same')
+      end
+
+      it 'does not perform a paired test when both samples have an standard deviation of zero' do
+        sample_1 = [1.0, 2.0, 3.0]
+        sample_2 = [2.0, 3.0, 4.0]
+
+        error_msg = 'Standard deviation for the difference is zero. Please, reconsider sample contents'
+
+        expect do
+          described_class.paired_test(alpha, :one_tail, sample_1, sample_2)
+        end.to raise_error(described_class::ZeroStdError,  error_msg)
+      end
+    end
+
     # example ONE
     # explained here: https://onlinecourses.science.psu.edu/stat500/node/51
     # Trace metals in drinking water affect the flavor and an unusually high concentration can pose a health hazard.

--- a/spec/statistics/statistical_test/t_test_spec.rb
+++ b/spec/statistics/statistical_test/t_test_spec.rb
@@ -7,11 +7,12 @@ describe Statistics::StatisticalTest::TTest do
 
       it 'does not perform a t-test when standard deviation of zero' do
         sample_1 = [1.0, 1.0, 1.0]
+        mean = 1.0
 
-        error_msg = 'Standard deviation for the difference is zero. Please, reconsider sample contents'
+        error_msg = 'Standard deviation for the difference or group is zero. Please, reconsider sample contents'
 
         expect do
-          described_class.perform(alpha, :one_tail, sample_1)
+          described_class.perform(alpha, :one_tail, mean, sample_1)
         end.to raise_error(described_class::ZeroStdError,  error_msg)
       end
     end
@@ -89,7 +90,7 @@ describe Statistics::StatisticalTest::TTest do
         sample_1 = [1.0, 2.0, 3.0]
         sample_2 = [2.0, 3.0, 4.0]
 
-        error_msg = 'Standard deviation for the difference is zero. Please, reconsider sample contents'
+        error_msg = 'Standard deviation for the difference or group is zero. Please, reconsider sample contents'
 
         expect do
           described_class.paired_test(alpha, :one_tail, sample_1, sample_2)


### PR DESCRIPTION
**Fixes: #20**

This change allow us to know when it's necessary to revisit the specified samples when we have an standard devation of zero, which in practice seems to be an edge case. We are implementing this
approach following the answer made to this [question](https://stats.stackexchange.com/questions/78570/t-test-with-sample-standard-deviation-of-zero-possible) where it's important to reconsider samples with std of zero.