### PR TITLE
Fix average difference in two samples ttest

### DIFF
--- a/lib/statistics/statistical_test/t_test.rb
+++ b/lib/statistics/statistical_test/t_test.rb
@@ -36,7 +36,7 @@ module Statistics
 
                     standard_error = Math.sqrt(left_root + right_root)
 
-                    (sample_left_mean - sample_right_mean)/standard_error.to_f
+                    (sample_left_mean - sample_right_mean).abs/standard_error.to_f
                   end
 
         probability = Distribution::TStudent.new(degrees_of_freedom).cumulative_function(t_score)

--- a/lib/statistics/statistical_test/t_test.rb
+++ b/lib/statistics/statistical_test/t_test.rb
@@ -43,7 +43,8 @@ module Statistics
         p_value = 1 - probability
         p_value *= 2 if tails == :two_tail
 
-        { probability: probability,
+        { t_score: t_score,
+          probability: probability,
           p_value: p_value,
           alpha: alpha,
           null: alpha < p_value,
@@ -71,7 +72,8 @@ module Statistics
         p_value = 1 - probability
         p_value *= 2 if tails == :two_tail
 
-        { probability: probability,
+        { t_score: t_score,
+          probability: probability,
           p_value: p_value,
           alpha: alpha,
           null: alpha < p_value,

--- a/spec/statistics/statistical_test/t_test_spec.rb
+++ b/spec/statistics/statistical_test/t_test_spec.rb
@@ -50,11 +50,13 @@ describe Statistics::StatisticalTest::TTest do
 
         result = described_class.perform(alpha, :two_tail, older_adults, younger_adults)
 
+        expect(result[:t_score].round(4)).to eq 4.2575
         expect(result[:null]).to be false
         expect(result[:alternative]).to be true
 
         result = described_class.perform(alpha, :two_tail, younger_adults, older_adults)
 
+        expect(result[:t_score].round(4)).to eq 4.2575
         expect(result[:null]).to be false
         expect(result[:alternative]).to be true
       end
@@ -72,11 +74,13 @@ describe Statistics::StatisticalTest::TTest do
 
         result = described_class.perform(alpha, :one_tail, experimental, comparison)
 
+        expect(result[:t_score].round(4)).to eq 3.5341
         expect(result[:null]).to be false
         expect(result[:alternative]).to be true
 
         result = described_class.perform(alpha, :one_tail, comparison, experimental)
 
+        expect(result[:t_score].round(4)).to eq 3.5341
         expect(result[:null]).to be false
         expect(result[:alternative]).to be true
       end
@@ -120,6 +124,7 @@ describe Statistics::StatisticalTest::TTest do
 
       result = described_class.paired_test(alpha, :one_tail, group_one, group_two)
 
+      expect(result[:t_score].round(4)).to eq 4.8638
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
     end
@@ -134,6 +139,7 @@ describe Statistics::StatisticalTest::TTest do
 
       result = described_class.paired_test(alpha, :one_tail, before, after)
 
+      expect(result[:t_score].round(4)).to eq 4.9258
       expect(result[:p_value].round(4)).to eq 0.0006
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
@@ -146,6 +152,7 @@ describe Statistics::StatisticalTest::TTest do
 
       result = described_class.paired_test(alpha, :two_tail, before, after)
 
+      expect(result[:t_score].round(4)).to eq 4.9258
       expect(result[:p_value].round(4)).to eq 0.0012
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
@@ -166,6 +173,7 @@ describe Statistics::StatisticalTest::TTest do
 
       result = described_class.paired_test(alpha, :two_tail, five_mts, ten_mts)
 
+      expect(result[:t_score].round(4)).to eq 2.3697
       expect(result[:p_value].round(3)).to eq 0.026
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true

--- a/spec/statistics/statistical_test/t_test_spec.rb
+++ b/spec/statistics/statistical_test/t_test_spec.rb
@@ -52,6 +52,11 @@ describe Statistics::StatisticalTest::TTest do
 
         expect(result[:null]).to be false
         expect(result[:alternative]).to be true
+
+        result = described_class.perform(alpha, :two_tail, younger_adults, older_adults)
+
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
       end
 
       # example TWO
@@ -66,6 +71,11 @@ describe Statistics::StatisticalTest::TTest do
         alpha = 0.01
 
         result = described_class.perform(alpha, :one_tail, experimental, comparison)
+
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+
+        result = described_class.perform(alpha, :one_tail, comparison, experimental)
 
         expect(result[:null]).to be false
         expect(result[:alternative]).to be true


### PR DESCRIPTION
This PR fixes the difference of average between means when two samples calculating T-test.

I expect the following result at test case of Statistics::StatisticalTest::TTest.

```
{:probability=>0.999763168344053, :p_value=>0.00047366331189402366, :alpha=>0.05, :null=>false, :alternative=>true, :confidence_level=>0.95}
```

but,

```
{:probability=>0.00023683165594697088, :p_value=>1.999526336688106, :alpha=>0.05, :null=>true, :alternative=>false, :confidence_level=>0.95}
```

I think that is solved by adding abs process to results of `(sample_left_mean - sample_right_mean)`.

```
(sample_left_mean - sample_right_mean).abs/standard_error.to_f
```