### PR TITLE
Add Inverse Standard Normal Distribution

### DIFF
--- a/lib/statistics/distribution/normal.rb
+++ b/lib/statistics/distribution/normal.rb
@@ -79,5 +79,58 @@ module Statistics
         euler/Math.sqrt(2 * Math::PI)
       end
     end
+
+    # Standard Normal Inverse distribution:
+    # References:
+    # https://en.wikipedia.org/wiki/Inverse_distribution
+    # http://www.source-code.biz/snippets/vbasic/9.htm
+    class StandardNormalInverse < StandardNormal
+      A1 = -39.6968302866538
+      A2 = 220.946098424521
+      A3 = -275.928510446969
+      A4 = 138.357751867269
+      A5 = -30.6647980661472
+      A6 = 2.50662827745924
+      B1 = -54.4760987982241
+      B2 = 161.585836858041
+      B3 = -155.698979859887
+      B4 = 66.8013118877197
+      B5 = -13.2806815528857
+      C1 = -7.78489400243029E-03
+      C2 = -0.322396458041136
+      C3 = -2.40075827716184
+      C4 = -2.54973253934373
+      C5 =  4.37466414146497
+      C6 =  2.93816398269878
+      D1 =  7.78469570904146E-03
+      D2 =  0.32246712907004
+      D3 =  2.445134137143
+      D4 =  3.75440866190742
+      P_LOW = 0.02425
+      P_HIGH = 1 - P_LOW
+
+      def density_function(_)
+        raise NotImplementedError
+      end
+
+      def random(elements: 1, seed: Random.new_seed)
+        raise NotImplementedError
+      end
+
+      def cumulative_function(value)
+        raise ArgumentError if value < 0 || value > 1
+        if value < P_LOW
+          q = (-2 * Math::log(value))**0.5
+          (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1)
+        elsif value <= P_HIGH
+          q = value - 0.5
+          r = q * q
+          (((((A1 * r + A2) * r + A3) * r + A4) * r + A5) * r + A6) * q / (((((B1 * r + B2) * r + B3) * r + B4) * r + B5) * r + 1)
+        else
+          q = (-2 * Math::log(1 - value))**0.5
+          (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1)
+        end
+      end
+    end
   end
 end

--- a/lib/statistics/distribution/normal.rb
+++ b/lib/statistics/distribution/normal.rb
@@ -80,7 +80,7 @@ module Statistics
       end
     end
 
-    # Standard Normal Inverse distribution:
+    # Inverse Standard Normal distribution:
     # References:
     # https://en.wikipedia.org/wiki/Inverse_distribution
     # http://www.source-code.biz/snippets/vbasic/9.htm
@@ -100,12 +100,12 @@ module Statistics
       C2 = -0.322396458041136
       C3 = -2.40075827716184
       C4 = -2.54973253934373
-      C5 =  4.37466414146497
-      C6 =  2.93816398269878
-      D1 =  7.78469570904146E-03
-      D2 =  0.32246712907004
-      D3 =  2.445134137143
-      D4 =  3.75440866190742
+      C5 = 4.37466414146497
+      C6 = 2.93816398269878
+      D1 = 7.78469570904146E-03
+      D2 = 0.32246712907004
+      D3 = 2.445134137143
+      D4 = 3.75440866190742
       P_LOW = 0.02425
       P_HIGH = 1 - P_LOW
 

--- a/lib/statistics/distribution/normal.rb
+++ b/lib/statistics/distribution/normal.rb
@@ -118,7 +118,8 @@ module Statistics
       end
 
       def cumulative_function(value)
-        raise ArgumentError if value < 0 || value > 1
+        return 0 if value < 0 || value > 1
+
         if value < P_LOW
           q = (-2 * Math::log(value))**0.5
           (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1)

--- a/lib/statistics/distribution/normal.rb
+++ b/lib/statistics/distribution/normal.rb
@@ -84,7 +84,7 @@ module Statistics
     # References:
     # https://en.wikipedia.org/wiki/Inverse_distribution
     # http://www.source-code.biz/snippets/vbasic/9.htm
-    class StandardNormalInverse < StandardNormal
+    class InverseStandardNormal < StandardNormal
       A1 = -39.6968302866538
       A2 = 220.946098424521
       A3 = -275.928510446969
@@ -118,17 +118,19 @@ module Statistics
       end
 
       def cumulative_function(value)
-        return 0 if value <= 0 || value >= 1
+        return if value < 0.0 || value > 1.0
+        return -1.0 * Float::INFINITY if value.zero?
+        return Float::INFINITY if value == 1.0
 
         if value < P_LOW
-          q = (-2 * Math::log(value))**0.5
-          (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1)
+          q = Math.sqrt((Math.log(value) * -2.0))
+          (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1.0)
         elsif value <= P_HIGH
           q = value - 0.5
-          r = q * q
-          (((((A1 * r + A2) * r + A3) * r + A4) * r + A5) * r + A6) * q / (((((B1 * r + B2) * r + B3) * r + B4) * r + B5) * r + 1)
+          r = q ** 2
+          (((((A1 * r + A2) * r + A3) * r + A4) * r + A5) * r + A6) * q / (((((B1 * r + B2) * r + B3) * r + B4) * r + B5) * r + 1.0)
         else
-          q = (-2 * Math::log(1 - value))**0.5
+          q = Math.sqrt((Math.log(1 - value) * -2.0))
           (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1)
         end
       end

--- a/lib/statistics/distribution/normal.rb
+++ b/lib/statistics/distribution/normal.rb
@@ -131,7 +131,7 @@ module Statistics
           (((((A1 * r + A2) * r + A3) * r + A4) * r + A5) * r + A6) * q / (((((B1 * r + B2) * r + B3) * r + B4) * r + B5) * r + 1.0)
         else
           q = Math.sqrt((Math.log(1 - value) * -2.0))
-          (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1)
+          - (((((C1 * q + C2) * q + C3) * q + C4) * q + C5) * q + C6) / ((((D1 * q + D2) * q + D3) * q + D4) * q + 1)
         end
       end
     end

--- a/lib/statistics/distribution/normal.rb
+++ b/lib/statistics/distribution/normal.rb
@@ -118,7 +118,7 @@ module Statistics
       end
 
       def cumulative_function(value)
-        return 0 if value < 0 || value > 1
+        return 0 if value <= 0 || value >= 1
 
         if value < P_LOW
           q = (-2 * Math::log(value))**0.5

--- a/spec/statistics/distribution/normal_spec.rb
+++ b/spec/statistics/distribution/normal_spec.rb
@@ -98,18 +98,21 @@ describe Statistics::Distribution::StandardNormal do
   end
 end
 
-describe Statistics::Distribution::StandardNormalInverse do
+describe Statistics::Distribution::InverseStandardNormal do
   let(:standard_inverse_distribution) { described_class.new }
 
   describe '#cumulative_function' do
     it 'returns the expected probabilities for the standard normal inverse distribution' do
       # results have been taken here https://www.excelfunctions.net/excel-normsinv-function.html
+      expect(standard_inverse_distribution.cumulative_function(-0.0000001)).to be_nil
+      expect(standard_inverse_distribution.cumulative_function(0)).to eq -Float::INFINITY
       expect(standard_inverse_distribution.cumulative_function(0.25)).to eq -0.6744897502234195
+      expect(standard_inverse_distribution.cumulative_function(0.356245)).to eq -0.3685140105744644
       expect(standard_inverse_distribution.cumulative_function(0.55)).to eq 0.12566134687610314
+      expect(standard_inverse_distribution.cumulative_function(0.69865437)).to eq 0.520534254262422
       expect(standard_inverse_distribution.cumulative_function(0.9)).to eq 1.281551564140072
-
-      expect(standard_inverse_distribution.cumulative_function(0)).to be_zero
-      expect(standard_inverse_distribution.cumulative_function(1)).to be_zero
+      expect(standard_inverse_distribution.cumulative_function(1)).to eq Float::INFINITY
+      expect(standard_inverse_distribution.cumulative_function(1.0000001)).to be_nil
     end
   end
 

--- a/spec/statistics/distribution/normal_spec.rb
+++ b/spec/statistics/distribution/normal_spec.rb
@@ -108,8 +108,8 @@ describe Statistics::Distribution::StandardNormalInverse do
       expect(standard_inverse_distribution.cumulative_function(0.55)).to eq 0.12566134687610314
       expect(standard_inverse_distribution.cumulative_function(0.9)).to eq 1.281551564140072
 
-      expect(standard_inverse_distribution.cumulative_function(-0.000001)).to be_zero
-      expect(standard_inverse_distribution.cumulative_function(1.000001)).to be_zero
+      expect(standard_inverse_distribution.cumulative_function(0)).to be_zero
+      expect(standard_inverse_distribution.cumulative_function(1)).to be_zero
     end
   end
 

--- a/spec/statistics/distribution/normal_spec.rb
+++ b/spec/statistics/distribution/normal_spec.rb
@@ -97,3 +97,39 @@ describe Statistics::Distribution::StandardNormal do
     end
   end
 end
+
+describe Statistics::Distribution::StandardNormalInverse do
+  let(:standard_inverse_distribution) { described_class.new }
+
+  describe '#cumulative_function' do
+    it 'returns the expected probabilities for the standard normal inverse distribution' do
+      # results have been taken here https://www.excelfunctions.net/excel-normsinv-function.html
+      expect(standard_inverse_distribution.cumulative_function(0.25)).to eq -0.6744897502234195
+      expect(standard_inverse_distribution.cumulative_function(0.55)).to eq 0.12566134687610314
+      expect(standard_inverse_distribution.cumulative_function(0.9)).to eq 1.281551564140072
+
+      expect { standard_inverse_distribution.cumulative_function(-0.000001) }.to raise_error ArgumentError
+      expect { standard_inverse_distribution.cumulative_function(1.000001) }.to raise_error ArgumentError
+    end
+  end
+
+  describe '#density_function' do
+    let(:value) { 0.25 }
+
+    subject { described_class.new.density_function(value) }
+
+    it 'is not implemented' do
+      expect { subject }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#random' do
+    let(:value) { 0.25 }
+
+    subject { described_class.new.random(elements: value, seed: Random.new_seed) }
+
+    it 'is not implemented' do
+      expect { subject }.to raise_error NotImplementedError
+    end
+  end
+end

--- a/spec/statistics/distribution/normal_spec.rb
+++ b/spec/statistics/distribution/normal_spec.rb
@@ -108,8 +108,8 @@ describe Statistics::Distribution::StandardNormalInverse do
       expect(standard_inverse_distribution.cumulative_function(0.55)).to eq 0.12566134687610314
       expect(standard_inverse_distribution.cumulative_function(0.9)).to eq 1.281551564140072
 
-      expect { standard_inverse_distribution.cumulative_function(-0.000001) }.to raise_error ArgumentError
-      expect { standard_inverse_distribution.cumulative_function(1.000001) }.to raise_error ArgumentError
+      expect(standard_inverse_distribution.cumulative_function(-0.000001)).to be_zero
+      expect(standard_inverse_distribution.cumulative_function(1.000001)).to be_zero
     end
   end
 

--- a/spec/statistics/distribution/normal_spec.rb
+++ b/spec/statistics/distribution/normal_spec.rb
@@ -111,6 +111,7 @@ describe Statistics::Distribution::InverseStandardNormal do
       expect(standard_inverse_distribution.cumulative_function(0.55)).to eq 0.12566134687610314
       expect(standard_inverse_distribution.cumulative_function(0.69865437)).to eq 0.520534254262422
       expect(standard_inverse_distribution.cumulative_function(0.9)).to eq 1.281551564140072
+      expect(standard_inverse_distribution.cumulative_function(0.98)).to eq 2.0537489090030308
       expect(standard_inverse_distribution.cumulative_function(1)).to eq Float::INFINITY
       expect(standard_inverse_distribution.cumulative_function(1.0000001)).to be_nil
     end


### PR DESCRIPTION
Hello, first of all thanks for the gem!
In my project I need `NORMSDIST` Excel function in Ruby and your solution works perfect.

On the other I also need `NORMSINV` function. It seems like there is no such a solution for now. I did some research and found an algorithm which works precisely as expected.

I am not sure, if this type of distribution supports `random` and `density_function`, so I left them as `not implemented` but provided needed algorithm with specific tests.



