### PR TITLE
Coerce to rational instead of float to perform operations with BigDecimal

### DIFF
--- a/lib/math.rb
+++ b/lib/math.rb
@@ -9,11 +9,11 @@ module Math
   end
 
   def self.combination(n, r)
-    self.factorial(n)/(self.factorial(r) * self.factorial(n - r)).to_f # n!/(r! * [n - r]!)
+    self.factorial(n)/(self.factorial(r) * self.factorial(n - r)).to_r # n!/(r! * [n - r]!)
   end
 
   def self.permutation(n, k)
-    self.factorial(n)/self.factorial(n - k).to_f
+    self.factorial(n)/self.factorial(n - k).to_r
   end
 
   # Function adapted from the python implementation that exists in https://en.wikipedia.org/wiki/Simpson%27s_rule#Sample_implementation
@@ -24,7 +24,8 @@ module Math
       return
     end
 
-    h = (b - a)/n.to_f
+    h = (b - a)/n.to_r
+
     resA = yield(a)
     resB = yield(b)
 
@@ -45,7 +46,7 @@ module Math
 
   def self.lower_incomplete_gamma_function(s, x)
     # The greater the iterations, the better. That's why we are iterating 10_000 * x times
-    self.simpson_rule(0, x, (10_000 * x.round).round) do |t|
+    self.simpson_rule(0, x.to_r, (10_000 * x.round).round) do |t|
       (t ** (s - 1)) * Math.exp(-t)
     end
   end
@@ -72,7 +73,7 @@ module Math
     # To avoid overflow problems, the implementation applies the logarithm properties
     # to calculate in a faster and safer way the values.
     lbet_ab = (Math.lgamma(alp)[0] + Math.lgamma(bet)[0] - Math.lgamma(alp + bet)[0]).freeze
-    front = (Math.exp(Math.log(x) * alp + Math.log(1.0 - x) * bet - lbet_ab) / alp.to_f).freeze
+    front = (Math.exp(Math.log(x) * alp + Math.log(1.0 - x) * bet - lbet_ab) / alp.to_r).freeze
 
     # This is the non-log version of the left part of the formula (before the continuous fraction)
     # down_left = alp * self.beta_function(alp, bet)

--- a/lib/statistics/distribution/bernoulli.rb
+++ b/lib/statistics/distribution/bernoulli.rb
@@ -24,7 +24,7 @@ module Statistics
       end
 
       def self.skewness(p)
-        (1.0 - 2.0*p).to_f / Math.sqrt(p * (1.0 - p))
+        (1.0 - 2.0*p).to_r / Math.sqrt(p * (1.0 - p))
       end
 
       def self.kurtosis(p)

--- a/lib/statistics/distribution/beta.rb
+++ b/lib/statistics/distribution/beta.rb
@@ -4,8 +4,8 @@ module Statistics
       attr_accessor :alpha, :beta
 
       def initialize(alp, bet)
-        self.alpha = alp.to_f
-        self.beta = bet.to_f
+        self.alpha = alp.to_r
+        self.beta = bet.to_r
       end
 
       def cumulative_function(value)

--- a/lib/statistics/distribution/empirical.rb
+++ b/lib/statistics/distribution/empirical.rb
@@ -19,7 +19,7 @@ module Statistics
           summation
         end
 
-        cumulative_sum / samples.size.to_f
+        cumulative_sum / samples.size.to_r
       end
     end
   end

--- a/lib/statistics/distribution/f.rb
+++ b/lib/statistics/distribution/f.rb
@@ -10,7 +10,7 @@ module Statistics
 
       # Formula extracted from http://www.itl.nist.gov/div898/handbook/eda/section3/eda3665.htm#CDF
       def cumulative_function(value)
-        k = d2/(d2 + d1 * value.to_f)
+        k = d2/(d2 + d1 * value.to_r)
 
         1 - Math.incomplete_beta_function(k, d2/2.0, d1/2.0)
       end
@@ -18,28 +18,28 @@ module Statistics
       def density_function(value)
         return if d1 < 0 || d2 < 0 # F-pdf is well defined for the [0, +infinity) interval.
 
-        val = value.to_f
+        val = value.to_r
         upper = ((d1 * val) ** d1) * (d2**d2)
         lower = (d1 * val + d2) ** (d1 + d2)
-        up = Math.sqrt(upper/lower.to_f)
+        up = Math.sqrt(upper/lower.to_r)
         down = val * Math.beta_function(d1/2.0, d2/2.0)
 
-        up/down.to_f
+        up/down.to_r
       end
 
       def mean
         return if d2 <= 2
 
-        d2/(d2 - 2).to_f
+        d2/(d2 - 2).to_r
       end
 
       def mode
         return if d1 <= 2
 
-        left = (d1 - 2)/d1.to_f
-        right = d2/(d2 + 2).to_f
+        left = (d1 - 2)/d1.to_r
+        right = d2/(d2 + 2).to_r
 
-        left * right
+        (left * right).to_f
       end
     end
   end

--- a/lib/statistics/distribution/geometric.rb
+++ b/lib/statistics/distribution/geometric.rb
@@ -4,7 +4,7 @@ module Statistics
       attr_accessor :probability_of_success, :always_success_allowed
 
       def initialize(p, always_success: false)
-        self.probability_of_success = p.to_f
+        self.probability_of_success = p.to_r
         self.always_success_allowed = always_success
       end
 

--- a/lib/statistics/distribution/logseries.rb
+++ b/lib/statistics/distribution/logseries.rb
@@ -6,7 +6,7 @@ module Statistics
         k = k.to_i
 
         left = (-1.0 / Math.log(1.0 - p))
-        right = (p ** k).to_f
+        right = (p ** k).to_r
 
         left * right / k
       end
@@ -44,7 +44,7 @@ module Statistics
         up = p + Math.log(1.0 - p)
         down = ((1.0 - p) ** 2) * (Math.log(1.0 - p) ** 2)
 
-        (-1.0 * p) * (up / down.to_f)
+        (-1.0 * p) * (up / down.to_r)
       end
     end
   end

--- a/lib/statistics/distribution/negative_binomial.rb
+++ b/lib/statistics/distribution/negative_binomial.rb
@@ -25,21 +25,21 @@ module Statistics
       end
 
       def mean
-        (probability_per_trial * number_of_failures)/(1 - probability_per_trial).to_f
+        (probability_per_trial * number_of_failures)/(1 - probability_per_trial).to_r
       end
 
       def variance
-        (probability_per_trial * number_of_failures)/((1 - probability_per_trial) ** 2).to_f
+        (probability_per_trial * number_of_failures)/((1 - probability_per_trial) ** 2).to_r
       end
 
       def skewness
-        (1 + probability_per_trial).to_f / Math.sqrt(probability_per_trial * number_of_failures)
+        (1 + probability_per_trial).to_r / Math.sqrt(probability_per_trial * number_of_failures)
       end
 
       def mode
         if number_of_failures > 1
           up = probability_per_trial * (number_of_failures - 1)
-          down = (1 - probability_per_trial).to_f
+          down = (1 - probability_per_trial).to_r
 
           (up/down).floor
         elsif number_of_failures <= 1

--- a/lib/statistics/distribution/normal.rb
+++ b/lib/statistics/distribution/normal.rb
@@ -5,9 +5,9 @@ module Statistics
       alias_method :mode, :mean
 
       def initialize(avg, std)
-        self.mean = avg.to_f
-        self.standard_deviation = std.to_f
-        self.variance = std.to_f**2
+        self.mean = avg.to_r
+        self.standard_deviation = std.to_r
+        self.variance = std.to_r**2
       end
 
       def cumulative_function(value)

--- a/lib/statistics/distribution/poisson.rb
+++ b/lib/statistics/distribution/poisson.rb
@@ -18,7 +18,7 @@ module Statistics
         upper = (expected_number_of_occurrences ** k) * Math.exp(-expected_number_of_occurrences)
         lower = Math.factorial(k)
 
-        upper/lower.to_f
+        upper/lower.to_r
       end
 
       def cumulative_function(k)
@@ -31,7 +31,7 @@ module Statistics
 
         # We need the right tail, i.e.: The upper incomplete gamma function. This can be
         # achieved by doing a substraction between 1 and the lower incomplete gamma function.
-        1 - (upper/lower.to_f)
+        1 - (upper/lower.to_r)
       end
     end
   end

--- a/lib/statistics/distribution/t_student.rb
+++ b/lib/statistics/distribution/t_student.rb
@@ -29,7 +29,7 @@ module Statistics
         upper = Math.gamma((degrees_of_freedom + 1)/2.0)
         lower = Math.sqrt(degrees_of_freedom * Math::PI) * Math.gamma(degrees_of_freedom/2.0)
         left = upper/lower
-        right = (1 + ((value ** 2)/degrees_of_freedom.to_f)) ** -((degrees_of_freedom + 1)/2.0)
+        right = (1 + ((value ** 2)/degrees_of_freedom.to_r)) ** -((degrees_of_freedom + 1)/2.0)
 
         left * right
       end
@@ -64,8 +64,8 @@ module Statistics
           results << Math.simpson_rule(threshold, y, 10_000) do |t|
             up = Math.gamma((v+1)/2.0)
             down = Math.sqrt(Math::PI * v) * Math.gamma(v/2.0)
-            right = (1 + ((y ** 2)/v.to_f)) ** ((v+1)/2.0)
-            left = up/down.to_f
+            right = (1 + ((y ** 2)/v.to_r)) ** ((v+1)/2.0)
+            left = up/down.to_r
 
             left * right
           end

--- a/lib/statistics/distribution/uniform.rb
+++ b/lib/statistics/distribution/uniform.rb
@@ -4,8 +4,8 @@ module Statistics
       attr_accessor :left, :right
 
       def initialize(a, b)
-        self.left = a.to_f
-        self.right = b.to_f
+        self.left = a.to_r
+        self.right = b.to_r
       end
 
       def density_function(value)

--- a/lib/statistics/distribution/weibull.rb
+++ b/lib/statistics/distribution/weibull.rb
@@ -4,8 +4,8 @@ module Statistics
       attr_accessor :shape, :scale # k and lambda
 
       def initialize(k, lamb)
-        self.shape = k.to_f
-        self.scale = lamb.to_f
+        self.shape = k.to_r
+        self.scale = lamb.to_r
       end
 
       def cumulative_function(random_value)

--- a/lib/statistics/spearman_rank_coefficient.rb
+++ b/lib/statistics/spearman_rank_coefficient.rb
@@ -14,7 +14,7 @@ module Statistics
         if rankings.fetch(value, false)
           rankings[value][:rank] += (temporal_ranking + rankings[value][:counter])
           rankings[value][:counter] += 1
-          rankings[value][:tie_rank] = rankings[value][:rank] / rankings[value][:counter].to_f
+          rankings[value][:tie_rank] = rankings[value][:rank] / rankings[value][:counter].to_r
         else
           rankings[value] = { counter: 1, rank: temporal_ranking, tie_rank: temporal_ranking }
         end
@@ -35,7 +35,7 @@ module Statistics
       return if set_one.size == 0 && set_two.size == 0
 
       set_one_mean, set_two_mean = set_one.mean, set_two.mean
-      have_tie_ranks = (set_one + set_two).any? { |rank| rank.is_a?(Float) }
+      have_tie_ranks = (set_one + set_two).any? { |rank| rank.is_a?(Float) || rank.is_a?(Rational) }
 
       if have_tie_ranks
         numerator = 0
@@ -54,7 +54,7 @@ module Statistics
 
         denominator = Math.sqrt(squared_differences_set_one * squared_differences_set_two)
 
-        numerator / denominator.to_f # This is rho or spearman's coefficient.
+        numerator / denominator.to_r # This is rho or spearman's coefficient.
       else
         sum_squared_differences = set_one.each_with_index.reduce(0) do |memo, (rank_one, index)|
           memo += ((rank_one - set_two[index]) ** 2)
@@ -64,7 +64,7 @@ module Statistics
         numerator = 6 * sum_squared_differences
         denominator = ((set_one.size ** 3) - set_one.size)
 
-        1.0 - (numerator / denominator.to_f) # This is rho or spearman's coefficient.
+        1.0 - (numerator / denominator.to_r) # This is rho or spearman's coefficient.
       end
     end
   end

--- a/lib/statistics/statistical_test/chi_squared_test.rb
+++ b/lib/statistics/statistical_test/chi_squared_test.rb
@@ -8,12 +8,12 @@ module Statistics
         statistic = if expected.is_a? Numeric
                       observed.reduce(0) do |memo, observed_value|
                         up = (observed_value - expected) ** 2
-                        memo += (up/expected.to_f)
+                        memo += (up/expected.to_r)
                       end
                     else
                       expected.each_with_index.reduce(0) do |memo, (expected_value, index)|
                         up = (observed[index] - expected_value) ** 2
-                        memo += (up/expected_value.to_f)
+                        memo += (up/expected_value.to_r)
                       end
                     end
 

--- a/lib/statistics/statistical_test/f_test.rb
+++ b/lib/statistics/statistical_test/f_test.rb
@@ -19,7 +19,7 @@ module Statistics
         if args.size == 2
           variances = [args[0].variance, args[1].variance]
 
-          f_score = variances.max/variances.min.to_f
+          f_score = variances.max/variances.min.to_r
           df1 = 1 # k-1 (k = 2)
           df2 = args.flatten.size - 2 # N-k (k = 2)
         elsif args.size > 2
@@ -37,18 +37,18 @@ module Statistics
           variance_between_groups = iterator.reduce(0) do |summation, (size, index)|
             inner_calculation = size * ((sample_means[index] - overall_mean) ** 2)
 
-            summation += (inner_calculation / (total_groups - 1).to_f)
+            summation += (inner_calculation / (total_groups - 1).to_r)
           end
 
           # Variance within groups
           variance_within_groups = (0...total_groups).reduce(0) do |outer_summation, group_index|
             outer_summation += args[group_index].reduce(0) do |inner_sumation, observation|
               inner_calculation = ((observation - sample_means[group_index]) ** 2)
-              inner_sumation += (inner_calculation / (total_elements - total_groups).to_f)
+              inner_sumation += (inner_calculation / (total_elements - total_groups).to_r)
             end
           end
 
-          f_score = variance_between_groups/variance_within_groups.to_f
+          f_score = variance_between_groups/variance_within_groups.to_r
           df1 = total_groups - 1
           df2 = total_elements - total_groups
         end

--- a/lib/statistics/statistical_test/kolmogorov_smirnov_test.rb
+++ b/lib/statistics/statistical_test/kolmogorov_smirnov_test.rb
@@ -17,7 +17,7 @@ module Statistics
 
         # TODO: Validate calculation of Common alpha.
         common_alpha = Math.sqrt((-0.5 * Math.log(alpha)))
-        radicand = (group_one.size + group_two.size) / (group_one.size * group_two.size).to_f
+        radicand = (group_one.size + group_two.size) / (group_one.size * group_two.size).to_r
 
         critical_d = common_alpha * Math.sqrt(radicand)
         # critical_d = self.critical_d(alpha: alpha, n: samples.size)

--- a/lib/statistics/statistical_test/t_test.rb
+++ b/lib/statistics/statistical_test/t_test.rb
@@ -23,7 +23,7 @@ module Statistics
                     comparison_mean = args[0]
                     degrees_of_freedom = args[1].size - 1
 
-                    (data_mean - comparison_mean)/(data_std / Math.sqrt(args[1].size).to_f).to_f
+                    (data_mean - comparison_mean)/(data_std / Math.sqrt(args[1].size).to_r).to_r
                   else
                     sample_left_mean = args[0].mean
                     sample_left_variance = args[0].variance
@@ -31,12 +31,12 @@ module Statistics
                     sample_right_mean = args[1].mean
                     degrees_of_freedom = args.flatten.size - 2
 
-                    left_root = sample_left_variance/args[0].size.to_f
-                    right_root = sample_right_variance/args[1].size.to_f
+                    left_root = sample_left_variance/args[0].size.to_r
+                    right_root = sample_right_variance/args[1].size.to_r
 
                     standard_error = Math.sqrt(left_root + right_root)
 
-                    (sample_left_mean - sample_right_mean).abs/standard_error.to_f
+                    (sample_left_mean - sample_right_mean).abs/standard_error.to_r
                   end
 
         t_distribution = Distribution::TStudent.new(degrees_of_freedom)
@@ -72,7 +72,7 @@ module Statistics
 
         down = difference_std/Math.sqrt(differences.size)
 
-        t_score = (differences.mean - 0)/down.to_f
+        t_score = (differences.mean - 0)/down.to_r
 
         probability = Distribution::TStudent.new(degrees_of_freedom).cumulative_function(t_score)
 

--- a/lib/statistics/statistical_test/wilcoxon_rank_sum_test.rb
+++ b/lib/statistics/statistical_test/wilcoxon_rank_sum_test.rb
@@ -73,7 +73,7 @@ module Statistics
                     memo += ((t[:counter] ** 3) - t[:counter])/12.0
                   end
 
-        left = (total_group_one * total_group_two)/(n * (n - 1)).to_f
+        left = (total_group_one * total_group_two)/(n * (n - 1)).to_r
         right = (((n ** 3) - n)/12.0) - rank_sum
 
         Math.sqrt(left * right)
@@ -82,7 +82,7 @@ module Statistics
       private def ranked_sum_for(total, group)
         # sum rankings per group
         group.reduce(0) do |memo, element|
-          rank_of_element = total[element][:rank] / total[element][:counter].to_f
+          rank_of_element = total[element][:rank] / total[element][:counter].to_r
           memo += rank_of_element
         end
       end

--- a/ruby-statistics.gemspec
+++ b/ruby-statistics.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", '>= 3.6.0'
   spec.add_development_dependency "grb", '~> 0.4.1', '>= 0.4.1'
   spec.add_development_dependency 'byebug', '>= 9.1.0'
+  spec.add_development_dependency 'pry'
 end

--- a/spec/statistics/bigdecimal_spec.rb
+++ b/spec/statistics/bigdecimal_spec.rb
@@ -1,0 +1,478 @@
+require 'spec_helper'
+require 'bigdecimal'
+require 'bigdecimal/util'
+
+describe BigDecimal do
+  context 'when bigdecimal is passed to personalized math functions' do
+    it 'truncates the decimal numbers and calculates the factorial for the real part' do
+      expect(Math.factorial(BigDecimal(5.45354598234834, 16))).to eq 120
+    end
+
+    it 'calculates the possible permutations of k objects from a set of n elements' do
+      expect(Math.permutation(BigDecimal(15, 1), BigDecimal(4, 1))).to eq 32760
+      expect(Math.permutation(BigDecimal(16, 1), BigDecimal(3, 1))).to eq 3360 # 16 balls, choose 3.
+      expect(Math.permutation(BigDecimal(10, 1), BigDecimal(2, 1))).to eq 90 # 10 people to select 1th and 2nd place.
+    end
+
+    it 'calculates the possible combinations of k object from a set of n elements' do
+      expect(Math.combination(BigDecimal(16, 1), BigDecimal(3, 1))).to eq 560 # Order 16 balls in 3 ways.
+      expect(Math.combination(BigDecimal(5, 1), BigDecimal(3, 1))).to eq 10 # How to choose 3 people out of 5.
+      expect(Math.combination(BigDecimal(12, 1), BigDecimal(5, 1))).to eq 792 # How to choose 5 games out of 12.
+    end
+
+    it 'approximates a solution in the [a,b] interval for the integral of the specified function' do
+      lower = BigDecimal(rand(10), 1)
+      upper = BigDecimal(rand(11..20), 1)
+
+      function_a = Math.simpson_rule(lower, upper, 10_000) do |x|
+        x ** 2
+      end
+
+      function_b = Math.simpson_rule(lower, upper, 10_000) do |x|
+        Math.sin(x)
+      end
+
+      res_a = ((upper ** 3)/3.0) - ((lower ** 3)/3.0) # Integral of x^2
+      res_b = -Math.cos(upper) + Math.cos(lower) # Integral of sin(x)
+
+      expect(function_a.floor).to eq res_a.floor
+      expect(function_b.floor).to eq res_b.floor
+    end
+
+    it 'returns the expected calculationi for the lower incomplete gamma function' do
+      results = [0.6322, 0.594, 1.1536, 3.3992, 13.4283]
+
+      (1..5).each_with_index do |number, index|
+        expect(
+          Math.lower_incomplete_gamma_function(
+            BigDecimal(number, 1), BigDecimal(number, 1)
+          ).round(4)
+        ).to eq results[index]
+      end
+    end
+
+    it 'returns 1 for the special case x = y = 1 when calculating the beta function' do
+      expect(Math.beta_function(BigDecimal(1, 1), BigDecimal(1, 1))).to eq 1
+    end
+
+    it 'Calculates the expected values for the beta function' do
+      # TODO: Find a way to better test this instead of fixing some values.
+      result = [1, 0.1667, 0.0333, 0.0071, 0.0016]
+
+      (1..5).each_with_index do |number, index|
+        expectation = Math.beta_function(
+          BigDecimal(number, 1), BigDecimal(number, 1)
+        ).round(4)
+        expect(expectation).to eq result[index]
+      end
+    end
+
+    it 'calculates the expected values for the incomplete beta function' do
+      # The last 2 values:
+      # For 9 is 0.9999979537560903519733 which is rounding to 1.0
+      # For 10 is 1.0
+      results = [
+        0.19, 0.1808, 0.2557, 0.4059,
+        0.6230, 0.8418, 0.9685, BigDecimal(0.9985, 5),
+        BigDecimal(0.9999979537560903, 5), 1.0
+      ]
+
+      (1..10).each_with_index do |number, index|
+        expect(
+          Math.incomplete_beta_function(
+            (number/10.0).to_d(16), BigDecimal(number, 1), BigDecimal(number + 1, 1)
+          ).round(4)
+        ).to eq results[index]
+      end
+    end
+  end
+
+  context 'when bigdecimal is used in chi squared tests' do
+    it 'perform a goodness of fit test following example ONE' do
+      observed_counts = [
+        BigDecimal(212, 1), BigDecimal(147, 1), BigDecimal(103, 1),
+        BigDecimal(50, 1), BigDecimal(46, 1), BigDecimal(42, 1)
+      ]
+      expected = BigDecimal(100, 1)
+      result = StatisticalTest::ChiSquaredTest.goodness_of_fit(0.05, expected, observed_counts)
+
+      expect(result[:p_value]).to eq -6.509459637982218e-12
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+    end
+
+    it 'perform a goodness of fit test following example TWO' do
+      observed = [
+        BigDecimal(224, 1), BigDecimal(119, 1), BigDecimal(130, 1),
+        BigDecimal(48, 1), BigDecimal(59, 1)
+      ]
+      expected = [
+        BigDecimal(232, 1), BigDecimal(116, 1), BigDecimal(116, 1),
+        BigDecimal(58, 1), BigDecimal(58, 1)
+      ]
+
+      result = StatisticalTest::ChiSquaredTest.goodness_of_fit(0.05, expected, observed)
+
+      expect(result[:p_value].round(4)).to eq 0.4359
+      expect(result[:null]).to be true
+      expect(result[:alternative]).to be false
+    end
+  end
+
+  context 'when bigdecimal is used in F tests' do
+    # example ONE
+    # explained here: https://courses.lumenlearning.com/boundless-statistics/chapter/one-way-anova
+    # Four sororities took a random sample of sisters regarding their grade means for the past term.
+    # Using a significance level of 1%, is there a difference in mean grades among the sororities?
+    it 'performs a One way ANOVA Test following example ONE' do
+      sorority_one = [
+        BigDecimal(2.17, 3), BigDecimal(1.85, 3), BigDecimal(2.83, 3),
+        BigDecimal(1.69, 3), BigDecimal(3.33, 3)
+      ]
+      sorority_two = [
+        BigDecimal(2.63, 3), BigDecimal(1.77, 3), BigDecimal(3.25, 3),
+        BigDecimal(1.86, 3), BigDecimal(2.21, 3)
+      ]
+      sorority_three = [
+        BigDecimal(2.63, 3), BigDecimal(3.78, 3), BigDecimal(4.00, 3),
+        BigDecimal(2.55, 3), BigDecimal(2.45, 3)
+      ]
+      sorority_four = [
+        BigDecimal(3.79, 3), BigDecimal(3.45, 3), BigDecimal(3.08, 3),
+        BigDecimal(2.26, 3), BigDecimal(3.18, 3)
+      ]
+      alpha = 0.1
+
+      result = StatisticalTest::FTest.one_way_anova(alpha,
+                                             sorority_one,
+                                             sorority_two,
+                                             sorority_three,
+                                             sorority_four)
+
+      expect(result[:p_value].round(4)).to eq 0.1241
+
+      # Accept null hypotheses ?
+      expect(result[:null]).to be true
+
+      # Accept alternative hypotheses ?
+      expect(result[:alternative]).to be false
+
+      # Confidence level (90 %)
+      expect(result[:confidence_level]).to eq 0.9
+    end
+
+    # example TWO
+    # explained here: https://web.mst.edu/~psyworld/anovaexample.htm
+    # Susan Sound predicts that students will learn most effectively with a constant background sound,
+    # as opposed to an unpredictable sound or no sound at all. She randomly divides twenty-four students
+    # into three groups of eight. All students study a passage of text for 30 minutes.
+    # Those in group 1 study with background sound at a constant volume in the background.
+    # Those in group 2 study with noise that changes volume periodically.
+    # Those in group 3 study with no sound at all.
+    # After studying, all students take a 10 point multiple choice test over the material.
+    it 'perfoms a One way ANOVA Test following example TWO' do
+      constant_sound = [
+        BigDecimal(7, 1), BigDecimal(4, 1), BigDecimal(6, 1), BigDecimal(8, 1),
+        BigDecimal(6, 1), BigDecimal(6, 1), BigDecimal(2, 1), BigDecimal(9, 1)
+      ]
+      random_sound = [
+        BigDecimal(5, 1), BigDecimal(5, 1), BigDecimal(3, 1), BigDecimal(4, 1),
+        BigDecimal(4, 1), BigDecimal(7, 1), BigDecimal(2, 1), BigDecimal(2, 1)
+      ]
+      no_sound = [
+        BigDecimal(2, 1), BigDecimal(4, 1), BigDecimal(7, 1), BigDecimal(1, 1),
+        BigDecimal(2, 1), BigDecimal(1, 1), BigDecimal(5, 1), BigDecimal(5, 1)
+      ]
+      alpha = 0.05
+
+      result = StatisticalTest::FTest.one_way_anova(alpha,
+                                             constant_sound,
+                                             random_sound,
+                                             no_sound)
+
+      expect(result[:p_value].round(3)).to eq 0.045
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+    end
+  end
+
+  context 'when bigdecimal is used in kolmogorov smirnov tests' do
+    it 'computes a two-sided Kolmogorov-Smirnov test for two samples, following example ONE' do
+      # Data extracted from http://www.stats.ox.ac.uk/~massa/Lecture%2013.pdf
+      # calculation in R:
+      # > ks.test(c(1.2,1.4,1.9,3.7,4.4,4.8,9.7,17.3,21.1,28.4), c(5.6,6.5,6.6,6.9,9.2,10.4,10.6,19.3))
+      #
+      #   Two-sample Kolmogorov-Smirnov test
+      #
+      #   D = 0.6, p-value = 0.04987
+      #   alternative hypothesis: two-sided
+
+      group_one = [
+        BigDecimal(1.2, 3), BigDecimal(1.4, 3), BigDecimal(1.9, 3), BigDecimal(3.7, 3),
+        BigDecimal(4.4, 3), BigDecimal(4.8, 3), BigDecimal(9.7, 3), BigDecimal(17.3, 3),
+        BigDecimal(21.1, 3), BigDecimal(28.4, 3)
+      ]
+      group_two = [
+        BigDecimal(5.6, 3), BigDecimal(6.5, 3), BigDecimal(6.6, 3), BigDecimal(6.9, 3),
+        BigDecimal(9.2, 3), BigDecimal(10.4, 3), BigDecimal(10.6, 3), BigDecimal(19.3, 3)
+      ]
+
+      # alpha, by default, is 0.05
+      result = StatisticalTest::KSTest.two_samples(group_one: group_one, group_two: group_two)
+
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+      expect(result[:d_max]).to eq 0.6
+    end
+  end
+
+  context 'when bigdecimal is used in wilcoxon rank sum test' do
+    ## Examples
+    # Example ONE extracted from http://users.sussex.ac.uk/~grahamh/RM1web/Mann-Whitney%20worked%20example.pdf
+    # The  effectiveness  of  advertising  for  two  rival  products  (Brand  X  and Brand  Y)  was  compared.
+    #
+    # Example TWO and THREE extracted from http://webspace.ship.edu/pgmarr/Geo441/Lectures/Lec%207%20-%20Mann-Whitney%20and%20Paired%20Tests.pdf
+    # both examples tries to identify if there is significant difference between oceanic and continental
+    # earthquakes compared by magnitude (TWO) and depth (THREE).
+    it 'performs a wilcoxon rank sum/Mann-Whitney U test following example ONE' do
+      rating_x = [
+        BigDecimal(3, 1), BigDecimal(4, 1), BigDecimal(2, 1), BigDecimal(6, 1),
+        BigDecimal(2, 1), BigDecimal(5, 1)
+      ]
+      rating_y = [
+        BigDecimal(9, 1), BigDecimal(7, 1), BigDecimal(5, 1), BigDecimal(10, 1),
+        BigDecimal(6, 1), BigDecimal(8, 1)
+      ]
+
+      result = StatisticalTest::WilcoxonRankSumTest.new.perform(0.05, :two_tail, rating_x, rating_y)
+
+      expect(result[:u]).to eq 2
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+      expect(result[:p_value].round(2)).to eq 0.01
+    end
+
+    it 'performs a wilcoxon rank sum/Mann-Whitney U test following example TWO' do
+      oceanic_magnitudes = [
+        BigDecimal(3.9, 3), BigDecimal(4.0, 3), BigDecimal(4.1, 3), BigDecimal(4.3, 3),
+        BigDecimal(4.3, 3), BigDecimal(4.4, 3), BigDecimal(4.5, 3), BigDecimal(4.8, 3),
+        BigDecimal(5.4, 3), BigDecimal(6.3, 3), BigDecimal(6.8, 3), BigDecimal(6.8, 3)
+      ]
+      continental_magnitudes = [
+        BigDecimal(4.1, 3), BigDecimal(4.3, 3), BigDecimal(4.3, 3), BigDecimal(4.3, 3),
+        BigDecimal(4.4, 3), BigDecimal(4.4, 3), BigDecimal(4.5, 3), BigDecimal(4.6, 3),
+        BigDecimal(5.0, 3), BigDecimal(5.1, 3), BigDecimal(5.1, 3)
+      ]
+
+      result = StatisticalTest::WilcoxonRankSumTest.new.perform(0.05, :two_tail, oceanic_magnitudes, continental_magnitudes)
+
+      expect(result[:u]).to eq 63 # In the example, they use the largest instead of the lowest.
+      expect(result[:z].round(3)).to eq -0.186
+      expect(result[:null]).to be true
+      expect(result[:alternative]).to be false
+      expect(result[:p_value]).to eq 0.8525013990549617
+    end
+
+    it 'performs a wilcoxon rank sum/Mann-Whitney U test following example THREE' do
+      oceanic_earthquakes = [
+        BigDecimal(75, 1), BigDecimal(32, 1), BigDecimal(50, 1), BigDecimal(38, 1),
+        BigDecimal(19, 1), BigDecimal(44, 1), BigDecimal(33, 1), BigDecimal(102, 1),
+        BigDecimal(28, 1), BigDecimal(70, 1), BigDecimal(49, 1), BigDecimal(70, 1)
+      ]
+      continental_earthquakes = [
+        BigDecimal(69, 1), BigDecimal(99, 1), BigDecimal(135, 1), BigDecimal(115, 1),
+        BigDecimal(33, 1), BigDecimal(92, 1), BigDecimal(118, 1), BigDecimal(115, 1),
+        BigDecimal(92, 1), BigDecimal(89, 1), BigDecimal(101, 1)
+      ]
+
+      result = StatisticalTest::WilcoxonRankSumTest.new.perform(0.05, :two_tail, oceanic_earthquakes, continental_earthquakes)
+
+      expect(result[:u]).to eq 17.5
+      expect(result[:z].round(3)).to eq -2.988
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+      expect(result[:p_value]).to eq 0.002808806689028387
+    end
+  end
+
+  context 'when bigdecimal is used in t-tests' do
+    # Example with one sample
+    # explained here: https://secure.brightstat.com/index.php?id=40
+    # A random sample of 22 fifth grade pupils have a grade point average of 5.0 in maths
+    # with a standard deviation of 0.452, whereas marks range from 1 (worst) to 6 (excellent).
+    # The grade point average (GPA) of all fifth grade pupils of the last five years is 4.7.
+    # Is the GPA of the 22 pupils different from the populations’ GPA?
+    it 'performs a t-test with one sample for one tail' do
+      student_grades = [
+        BigDecimal(5, 3), BigDecimal(5.5, 3), BigDecimal(4.5, 3), BigDecimal(5, 3),
+        BigDecimal(5, 3), BigDecimal(6, 3), BigDecimal(5, 3), BigDecimal(5, 3),
+        BigDecimal(4.5, 3), BigDecimal(5, 3), BigDecimal(5, 3), BigDecimal(4.5, 3),
+        BigDecimal(4.5, 3), BigDecimal(5.5, 3), BigDecimal(4, 3), BigDecimal(5, 3),
+        BigDecimal(5, 3), BigDecimal(5.5, 3), BigDecimal(4.5, 3), BigDecimal(5.5, 3),
+        BigDecimal(5, 3), BigDecimal(5.5, 3)
+      ]
+      alpha = 0.05
+
+      result = StatisticalTest::TTest.perform(alpha, :one_tail, 4.7, student_grades)
+
+      expect(result[:p_value].round(6)).to eq 0.003114 # R 3.5.1. calculates the p_value as 0.003114
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+    end
+
+    it 'performs a t-test with one sample for two tails' do
+      student_grades = [
+        BigDecimal(5, 3), BigDecimal(5.5, 3), BigDecimal(4.5, 3), BigDecimal(5, 3),
+        BigDecimal(5, 3), BigDecimal(6, 3), BigDecimal(5, 3), BigDecimal(5, 3),
+        BigDecimal(4.5, 3), BigDecimal(5, 3), BigDecimal(5, 3), BigDecimal(4.5, 3),
+        BigDecimal(4.5, 3), BigDecimal(5.5, 3), BigDecimal(4, 3), BigDecimal(5, 3),
+        BigDecimal(5, 3), BigDecimal(5.5, 3), BigDecimal(4.5, 3), BigDecimal(5.5, 3),
+        BigDecimal(5, 3), BigDecimal(5.5, 3)
+      ]
+      alpha = 0.05
+
+      result = StatisticalTest::TTest.perform(alpha, :two_tail, 4.7, student_grades)
+
+      expect(result[:p_value].round(6)).to eq 0.006229 # R 3.5.1. calculates the p_value as 0.006229
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
+    end
+
+    context 'when two samples are specified' do
+      # example ONE
+      # explained here: http://faculty.webster.edu/woolflm/6aanswer.html
+      #  A research study was conducted to examine the differences between older and younger adults
+      #  on perceived life satisfaction. A pilot study was conducted to examine this hypothesis.
+      #  Ten older adults (over the age of 70) and ten younger adults (between 20 and 30) were give
+      #  a life satisfaction test (known to have high reliability and validity).
+      #  Scores on the measure range from 0 to 60 with high scores indicative of high life satisfaction;
+      #  low scores indicative of low life satisfaction. The data are presented below.
+
+      it 'performs a t-test following example ONE' do
+        older_adults = [
+          BigDecimal(45, 1), BigDecimal(38, 1), BigDecimal(52, 1), BigDecimal(48, 1),
+          BigDecimal(25, 1), BigDecimal(39, 1), BigDecimal(51, 1), BigDecimal(46, 1),
+          BigDecimal(55, 1), BigDecimal(46, 1)
+        ]
+        younger_adults = [
+          BigDecimal(34, 1), BigDecimal(22, 1), BigDecimal(15, 1), BigDecimal(27, 1),
+          BigDecimal(37, 1), BigDecimal(41, 1), BigDecimal(24, 1), BigDecimal(19, 1),
+          BigDecimal(26, 1), BigDecimal(36, 1)
+        ]
+        alpha = 0.05
+
+        result = StatisticalTest::TTest.perform(alpha, :two_tail, older_adults, younger_adults)
+
+        expect(result[:t_score].round(4)).to eq 4.2575
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+
+        result = StatisticalTest::TTest.perform(alpha, :two_tail, younger_adults, older_adults)
+
+        expect(result[:t_score].round(4)).to eq 4.2575
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+      end
+
+      # example TWO
+      # explained here: http://www.indiana.edu/%7Eeducy520/sec6342/week_10/ttest_exp.pdf
+      # Rosenthal and Jacobson (1968) informed classroom teachers that some of their students showed
+      # unusual potential for intellectual gains. Eight months later the students identified to teachers as
+      # having potentional for unusual intellectual gains showed significiantly greater gains performance
+      # on a test said to measure IQ than did children who were not so identified.
+      it 'performs a t-test following example TWO' do
+        experimental = [
+          BigDecimal(35, 1), BigDecimal(40, 1), BigDecimal(12, 1), BigDecimal(15, 1),
+          BigDecimal(21, 1), BigDecimal(14, 1), BigDecimal(46, 1), BigDecimal(10, 1),
+          BigDecimal(28, 1), BigDecimal(48, 1), BigDecimal(16, 1), BigDecimal(30, 1),
+          BigDecimal(32, 1), BigDecimal(48, 1), BigDecimal(31, 1), BigDecimal(22, 1),
+          BigDecimal(12, 1), BigDecimal(39, 1), BigDecimal(19, 1), BigDecimal(25, 1)
+        ]
+        comparison = [
+          BigDecimal(2, 1), BigDecimal(27, 1), BigDecimal(38, 1), BigDecimal(31, 1),
+          BigDecimal(1, 1), BigDecimal(19, 1), BigDecimal(1, 1), BigDecimal(34, 1),
+          BigDecimal(3, 1), BigDecimal(1, 1), BigDecimal(2, 1), BigDecimal(3, 1),
+          BigDecimal(2, 1), BigDecimal(1, 1), BigDecimal(2, 1), BigDecimal(1, 1),
+          BigDecimal(3, 1), BigDecimal(29, 1), BigDecimal(37, 1), BigDecimal(2, 1)
+        ]
+        alpha = 0.01
+
+        result = StatisticalTest::TTest.perform(alpha, :one_tail, experimental, comparison)
+
+        expect(result[:t_score].round(4)).to eq 3.5341
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+
+        result = StatisticalTest::TTest.perform(alpha, :one_tail, comparison, experimental)
+
+        expect(result[:t_score].round(4)).to eq 3.5341
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+      end
+    end
+
+    context 'when two samples are specified' do
+      # example ONE
+      # explained here: http://faculty.webster.edu/woolflm/6aanswer.html
+      #  A research study was conducted to examine the differences between older and younger adults
+      #  on perceived life satisfaction. A pilot study was conducted to examine this hypothesis.
+      #  Ten older adults (over the age of 70) and ten younger adults (between 20 and 30) were give
+      #  a life satisfaction test (known to have high reliability and validity).
+      #  Scores on the measure range from 0 to 60 with high scores indicative of high life satisfaction;
+      #  low scores indicative of low life satisfaction. The data are presented below.
+
+      it 'performs a t-test following example ONE' do
+        older_adults = [
+          BigDecimal(45, 1), BigDecimal(38, 1), BigDecimal(52, 1), BigDecimal(48, 1),
+          BigDecimal(25, 1), BigDecimal(39, 1), BigDecimal(51, 1), BigDecimal(46, 1),
+          BigDecimal(55, 1), BigDecimal(46, 1)
+        ]
+        younger_adults = [
+          BigDecimal(34, 1), BigDecimal(22, 1), BigDecimal(15, 1), BigDecimal(27, 1),
+          BigDecimal(37, 1), BigDecimal(41, 1), BigDecimal(24, 1), BigDecimal(19, 1),
+          BigDecimal(26, 1), BigDecimal(36, 1)
+        ]
+        alpha = 0.05
+
+        result = StatisticalTest::TTest.perform(alpha, :two_tail, older_adults, younger_adults)
+
+        expect(result[:t_score].round(4)).to eq 4.2575
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+
+        result = StatisticalTest::TTest.perform(alpha, :two_tail, younger_adults, older_adults)
+
+        expect(result[:t_score].round(4)).to eq 4.2575
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+      end
+    end
+
+    describe '.paired_test' do
+      # example ONE
+      # explained here: https://onlinecourses.science.psu.edu/stat500/node/51
+      # Trace metals in drinking water affect the flavor and an unusually high concentration can pose a health hazard.
+      # Ten pairs of data were taken measuring zinc concentration in bottom water and surface.
+      # Does the data suggest that the true average concentration in the bottom water exceeds that of surface water?
+      it 'performs a paired t-test following example ONE' do
+        group_one = [
+          BigDecimal(0.430, 4), BigDecimal(0.266, 4), BigDecimal(0.567, 4), BigDecimal(0.531, 4),
+          BigDecimal(0.707, 4), BigDecimal(0.716, 4), BigDecimal(0.651, 4), BigDecimal(0.589, 4),
+          BigDecimal(0.469, 4), BigDecimal(0.723, 4)
+        ]
+        group_two = [
+          BigDecimal(0.415, 4), BigDecimal(0.238, 4), BigDecimal(0.390, 4), BigDecimal(0.410, 4),
+          BigDecimal(0.605, 4), BigDecimal(0.609, 4), BigDecimal(0.632, 4), BigDecimal(0.523, 4),
+          BigDecimal(0.411, 4), BigDecimal(0.612, 4)
+        ]
+        alpha = 0.05
+
+        result = StatisticalTest::TTest.paired_test(alpha, :one_tail, group_one, group_two)
+
+        expect(result[:t_score].round(4)).to eq 4.8638
+        expect(result[:null]).to be false
+        expect(result[:alternative]).to be true
+      end
+    end
+  end
+end

--- a/spec/statistics/distribution/f_spec.rb
+++ b/spec/statistics/distribution/f_spec.rb
@@ -52,11 +52,11 @@ describe Statistics::Distribution::F do
   describe '#mode' do
     it 'returns the expected mode for the F distribution' do
       d1, d2 = rand(3..10), rand(10)
-      expected_mode = ((d1 - 2)/d1.to_f) * (d2/(d2 + 2).to_f)
+      expected_mode = ((d1 - 2)/d1.to_r) * (d2/(d2 + 2).to_r)
 
       f_distribution = described_class.new(d1, d2)
 
-      expect(f_distribution.mode).to eq expected_mode
+      expect(f_distribution.mode).to eq expected_mode.to_f
     end
 
     it 'is not defined for d1 values less or equal than 2' do

--- a/spec/statistics/spearman_rank_coefficient_spec.rb
+++ b/spec/statistics/spearman_rank_coefficient_spec.rb
@@ -89,7 +89,7 @@ describe Statistics::SpearmanRankCoefficient do
         frequency_rank = described_class.rank(data: frequency)
 
         rho = described_class.coefficient(volume_rank, frequency_rank)
-        expect(rho.round(3)).to eq -0.763
+        expect(rho.round(7)).to eq -0.7630357
       end
 
       it 'calcultes the spearman rank coefficient for example two' do
@@ -119,7 +119,7 @@ describe Statistics::SpearmanRankCoefficient do
 
         rho = described_class.coefficient(life_rank, cigarretes_rank)
 
-        expect(rho.round(5)).to eq -0.67442
+        expect(rho.round(7)).to eq -0.6744197
       end
     end
 

--- a/spec/statistics/statistical_test/chi_squared_test_spec.rb
+++ b/spec/statistics/statistical_test/chi_squared_test_spec.rb
@@ -45,10 +45,10 @@ describe Statistics::StatisticalTest::ChiSquaredTest do
   describe '.goodness_of_fit' do
     it 'perform a goodness of fit test following example ONE' do
       observed_counts = [212, 147, 103, 50, 46, 42]
-      expected = 100
+      expected = 100 # this is equal to [100, 100, 100, 100, 100, 100]
       result = described_class.goodness_of_fit(0.05, expected, observed_counts)
 
-      expect(result[:p_value]).to eq -6.509459637982218e-12
+      expect(result[:p_value]).to eq -6.509237593377293e-12
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
     end


### PR DESCRIPTION
fixes #34

This change allow us to perform operations with BigDecimal in a more perfomant way, also it sightly improves the accuracy of the calculations made.

This change also includes a full copy of the current spec suite but using BigDecimal instead of Numeric or Float, to make sure everything is working as expected.