### PR TITLE
Aliasing Distribution Causes Namespace Collision

### DIFF
--- a/lib/statistics/distribution.rb
+++ b/lib/statistics/distribution.rb
@@ -5,7 +5,3 @@ module Statistics
   end
 end
 
-# If Distribution is not defined, setup alias.
-if defined?(Statistics) && !(defined?(Distribution))
-  Distribution = Statistics::Distribution
-end

--- a/lib/statistics/version.rb
+++ b/lib/statistics/version.rb
@@ -1,3 +1,3 @@
 module Statistics
-  VERSION = "2.1.3"
+  VERSION = "2.1.4"
 end

--- a/spec/statistics/statistical_test/kolmogorov_smirnov_test_spec.rb
+++ b/spec/statistics/statistical_test/kolmogorov_smirnov_test_spec.rb
@@ -37,8 +37,8 @@ describe Statistics::StatisticalTest::KolmogorovSmirnovTest do
       # D = 1, p-value = 6.657e-08
       # alternative hypothesis: two-sided
 
-      men = Distribution::Normal.new(3.0, 1.0).random(elements: 10, seed: 100)
-      women = Distribution::Weibull.new(2.0, 3.0).random(elements: 20, seed: 100)
+      men = Statistics::Distribution::Normal.new(3.0, 1.0).random(elements: 10, seed: 100)
+      women = Statistics::Distribution::Weibull.new(2.0, 3.0).random(elements: 20, seed: 100)
 
       # alpha, by default, is 0.05
       result = described_class.two_samples(group_one: men, group_two: women)
@@ -55,8 +55,8 @@ describe Statistics::StatisticalTest::KolmogorovSmirnovTest do
       # D = 0.4, p-value = 0.873
       # alternative hypothesis: two-sided
 
-      men = Distribution::StandardNormal.new.random(elements: 500, seed: 10)
-      women = Distribution::StandardNormal.new.random(elements: 50, seed: 40)
+      men = Statistics::Distribution::StandardNormal.new.random(elements: 500, seed: 10)
+      women = Statistics::Distribution::StandardNormal.new.random(elements: 50, seed: 40)
 
       # alpha, by default, is 0.05
       result = described_class.two_samples(group_one: men, group_two: women)

--- a/spec/statistics/statistical_test/wilcoxon_rank_sum_test_spec.rb
+++ b/spec/statistics/statistical_test/wilcoxon_rank_sum_test_spec.rb
@@ -40,7 +40,7 @@ describe Statistics::StatisticalTest::WilcoxonRankSumTest do
   # earthquakes compared by magnitude (TWO) and depth (THREE).
   describe '#perform' do
     it 'always computes the test approximating the U-statistic to the standard normal distribution' do
-      expect_any_instance_of(Distribution::StandardNormal)
+      expect_any_instance_of(Statistics::Distribution::StandardNormal)
         .to receive(:cumulative_function).and_call_original
 
       result = test_class.perform(0.05, :two_tail, [1,2,3], [4,5,6])


### PR DESCRIPTION
**Description**
The gem loads prior to the main application code and aliasing the gems
namespace to a root namespace creates conflicts with main app. This
update removes the aliasing to prevent this from happening.

**Relates to Issue**
https://github.com/estebanz01/ruby-statistics/issues/45