### PR TITLE
Replace ruby action with maintained one

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.5
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1.1.3
+      uses: ruby/setup-ruby@v1.84.0
       with:
         ruby-version: 2.6.x
     - name: Build and test with Rake
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.5
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1.1.3
+      uses: ruby/setup-ruby@v1.84.0
       with:
         ruby-version: 2.7.x
     - name: Build and test with Rake


### PR DESCRIPTION
[actions/setup-ruby](https://github.com/actions/setup-ruby#setup-ruby) is deprecated in favour of https://github.com/ruby/setup-ruby