### PR TITLE
Upgrading ruby supported versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,22 +3,22 @@ name: Ruby
 on: [push]
 
 jobs:
-  build:
+  build: # Latest ruby
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1.120.0
       with:
-        ruby-version: 2.6.8
+        ruby-version: 3.1.2
     - name: Build and test with Rake
       run: |
         gem install bundler
         bundle install --jobs 2 --retry 1
         bundle exec rake
-  
+
   build_2_7:
 
     runs-on: ubuntu-latest
@@ -28,13 +28,13 @@ jobs:
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1.120.0
       with:
-        ruby-version: 2.7.4
+        ruby-version: 2.7.6
     - name: Build and test with Rake
       run: |
         gem install bundler
         bundle install --jobs 2 --retry 1
         bundle exec rake
-        
+
   build_3_0:
 
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1.120.0
       with:
-        ruby-version: 3.0.2
+        ruby-version: 3.0.4
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 A basic ruby gem that implements some statistical methods, functions and concepts to be used in any ruby environment without depending on any mathematical software like `R`, `Matlab`, `Octave` or similar.
 
 Unit test runs under the following ruby versions:
-* Ruby 2.5.1.
-* Ruby 2.6.0.
-* Ruby 2.6.3.
-* Ruby 2.6.5.
-* Ruby 2.7.
+* Ruby 2.7.6.
+* Ruby 3.0.4.
+* Ruby 3.1.2.
 
 We got the inspiration from the folks at [JStat](https://github.com/jstat/jstat) and some interesting lectures about [Keystroke dynamics](http://www.biometric-solutions.com/keystroke-dynamics.html).
 

--- a/lib/math.rb
+++ b/lib/math.rb
@@ -104,9 +104,9 @@ module Math
 
       d = 1.0 + numerator * d
       d = tiny if d.abs < tiny
-      d = 1.0 / d
+      d = 1.0 / d.to_r
 
-      c = 1.0 + numerator / c
+      c = 1.0 + numerator / c.to_r
       c = tiny if c.abs < tiny
 
       cd = (c*d).freeze

--- a/spec/statistics/bigdecimal_spec.rb
+++ b/spec/statistics/bigdecimal_spec.rb
@@ -117,6 +117,31 @@ describe BigDecimal do
       expect(result[:null]).to be true
       expect(result[:alternative]).to be false
     end
+
+    # The following test is based on the numbers reported in https://github.com/estebanz01/ruby-statistics/issues/78
+    # which give us a minimum test case scenario where the integral being solved with simpson's rule
+    # uses zero iterations, raising errors.
+    it 'performs a goodness of fit test with values that generates small chi statistics' do
+      observed_counts = [
+        BigDecimal(481, 1), BigDecimal(483, 1),
+        BigDecimal(482, 1), BigDecimal(488, 1),
+        BigDecimal(478, 1), BigDecimal(471, 1),
+        BigDecimal(477, 1), BigDecimal(479, 1),
+        BigDecimal(475, 1), BigDecimal(462, 1)
+      ]
+
+      expected = BigDecimal(477, 1)
+
+      result = {}
+
+      expect do
+        result = StatisticalTest::ChiSquaredTest.goodness_of_fit(0.01, expected, observed_counts)
+      end.not_to raise_error
+
+      expect(result[:p_value].round(4)).to eq(0.9995)
+      expect(result[:null]).to be true
+      expect(result[:alternative]).to be false
+    end
   end
 
   context 'when bigdecimal is used in F tests' do


### PR DESCRIPTION
This PR changes:
- the minimum supported ruby versions.
- it updates the CI to run latest supported versions as October 2022.
- Fixes the segfault `"ERROR(VpDivd): space for remainder too small"` when calculating pretty small numbers on the Beta Incomplete function.

