### PR TITLE
Fix p value in paired T-test

### DIFF
--- a/lib/statistics/statistical_test/t_test.rb
+++ b/lib/statistics/statistical_test/t_test.rb
@@ -74,10 +74,14 @@ module Statistics
 
         t_score = (differences.mean - 0)/down.to_r
 
-        probability = Distribution::TStudent.new(degrees_of_freedom).cumulative_function(t_score)
+        t_distribution = Distribution::TStudent.new(degrees_of_freedom)
+        probability = t_distribution.cumulative_function(t_score)
 
-        p_value = 1 - probability
-        p_value *= 2 if tails == :two_tail
+        p_value = if tails == :two_tail
+                  2 * (1 - t_distribution.cumulative_function(t_score.abs))
+                  else
+                    1 - probability
+                  end
 
         { t_score: t_score,
           probability: probability,

--- a/spec/statistics/statistical_test/t_test_spec.rb
+++ b/spec/statistics/statistical_test/t_test_spec.rb
@@ -190,5 +190,35 @@ describe Statistics::StatisticalTest::TTest do
       expect(result[:null]).to be false
       expect(result[:alternative]).to be true
     end
+
+    # Calculations match R:
+    #
+    # left_group <- c(0.12819915256260872, 0.24345459073897613, 0.27517650565714014, 0.8522185144081152, 0.05471111219486524)
+    # right_group <- c(0.3272414061985621, 0.2989306116723194, 0.642664937717922, 0.9476073892620895, 0.7050008194345182)
+    #
+    # t.test(left_group, right_group, alternative = 'two.sided', paired = TRUE, conf.level = 0.99)
+    #
+    #   Paired t-test
+    #
+    # data:  left_group and right_group
+    # t = -2.5202, df = 4, p-value = 0.06534
+    # alternative hypothesis: true mean difference is not equal to 0
+    # 99 percent confidence interval:
+    # -0.7732524  0.2261783
+    # sample estimates:
+    # mean difference
+    #     -0.2735371
+    it 'performs a paired t-test (two tail) returning a p_value always smaller than 1' do
+      left_group = [0.12819915256260872, 0.24345459073897613, 0.27517650565714014, 0.8522185144081152, 0.05471111219486524]
+      right_group = [0.3272414061985621, 0.2989306116723194, 0.642664937717922, 0.9476073892620895, 0.7050008194345182]
+      alpha = 0.01
+
+      result = described_class.paired_test(alpha, :two_tail, left_group, right_group)
+
+      expect(result[:t_score].round(4)).to eq -2.5202
+      expect(result[:p_value].round(5)).to eq 0.06534
+      expect(result[:null]).to be true
+      expect(result[:alternative]).to be false
+    end
   end
 end


### PR DESCRIPTION
Thank you for making this gem available!

I believe I've found (and fixed) a bug. In the [Student's T-test (Paired T-Test) wiki page](https://github.com/estebanz01/ruby-statistics/wiki/Student's-T-test#paired-t-test), we see the following example:

```ruby
left_group
# => [0.12819915256260872, 0.24345459073897613, 0.27517650565714014, 0.8522185144081152, 0.05471111219486524]
right_group
# => [0.3272414061985621, 0.2989306116723194, 0.642664937717922, 0.9476073892620895, 0.7050008194345182]
# ...
StatisticalTest::TTest.paired_test(alpha = 0.01, :two_tail, left_group, right_group)
# => {:t_score=>-2.520215812331144, :probability=>0.032670873044446366, :p_value=>1.9346582539111072, :alpha=>0.01, :null=>true, :alternative=>false, :confidence_level=>0.99}
```

Notice the `p-value` returned is greater greater than 1.

If we do the same calculation in R:
```R
left_group <- c(0.12819915256260872, 0.24345459073897613, 0.27517650565714014, 0.8522185144081152, 0.05471111219486524)
right_group <- c(0.3272414061985621, 0.2989306116723194, 0.642664937717922, 0.9476073892620895, 0.7050008194345182)

t.test(left_group, right_group, alternative = 'two.sided', paired = TRUE, conf.level = 0.99)

#   Paired t-test

# data:  left_group and right_group
# t = -2.5202, df = 4, p-value = 0.06534
# alternative hypothesis: true mean difference is not equal to 0
# 99 percent confidence interval:
# -0.7732524  0.2261783
# sample estimates:
# mean difference
#     -0.2735371
```

The `p-value` is calculated as `0.06534`.

I believe the root cause is the same as what was fixed for `.perform` in https://github.com/estebanz01/ruby-statistics/pull/24. In this PR I use that same fix for `.paired_test` and the specs corroborate the numbers in the R calculations.

Assuming this is accepted, the wiki should also be changed:

```ruby
# => [0.12819915256260872, 0.24345459073897613, 0.27517650565714014, 0.8522185144081152, 0.05471111219486524]
right_group
# => [0.3272414061985621, 0.2989306116723194, 0.642664937717922, 0.9476073892620895, 0.7050008194345182]


StatisticalTest::TTest.paired_test(alpha = 0.01, :two_tail, left_group, right_group)
# =>
# {:t_score=>-2.520215812331144,
#  :probability=>0.03267087304444638,
#  :p_value=>0.06534174608889276,
#  :alpha=>0.01,
#  :null=>true,
#  :alternative=>false,
#  :confidence_level=>0.99}
```

Thank you!