### PR TITLE
Replace Ruby 2.7 with Ruby 3.3.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,26 +9,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby 3.2
+    - name: Set up Ruby 3.3
       uses: ruby/setup-ruby@v1.165.1
       with:
-        ruby-version: 3.2
+        ruby-version: 3.3
     - name: Build and test with Rake
       run: |
         gem install bundler
         bundle install --jobs 2 --retry 1
         bundle exec rake
 
-  build_2_7:
+  build_3_2:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1.165.1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.2
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 A basic ruby gem that implements some statistical methods, functions and concepts to be used in any ruby environment without depending on any mathematical software like `R`, `Matlab`, `Octave` or similar.
 
 Unit test runs under the following ruby versions:
-* Ruby 2.7.6.
-* Ruby 3.0.4.
-* Ruby 3.1.2.
+* Ruby 3.0.
+* Ruby 3.1.
+* Ruby 3.2.
+* Ruby 3.3.
 
 We got the inspiration from the folks at [JStat](https://github.com/jstat/jstat) and some interesting lectures about [Keystroke dynamics](http://www.biometric-solutions.com/keystroke-dynamics.html).
 


### PR DESCRIPTION
### Summary
- Replace Ruby 2.7 that entered EOL on march 31st, 2023 with Ruby 3.3 that was released on christmas.