### PR TITLE
added chi square independence test for contingency tables, and unit tests

### DIFF
--- a/lib/statistics/statistical_test/chi_squared_test.rb
+++ b/lib/statistics/statistical_test/chi_squared_test.rb
@@ -1,6 +1,9 @@
 module Statistics
   module StatisticalTest
     class ChiSquaredTest
+
+      require 'matrix'
+
       def self.chi_statistic(expected, observed)
         # If the expected is a number, we asumme that all expected observations
         # has the same probability to occur, hence we expect to see the same number
@@ -39,7 +42,7 @@ module Statistics
       end
 
       # The following three functions serve to calculate a test of independence for contingency
-      # tables of the type
+      # tables (short: ct) of the type
       #
       #      A   B
       # X   20  18
@@ -47,10 +50,10 @@ module Statistics
       #
       # They have been tested using 2x2 and 3x3 tables.
       #
-      def self.test_of_independence(alpha, observed)
-        expected = calculate_expected(observed)
-        df = (observed.size - 1) * (observed.transpose.size - 1)
-        chi_score = calculate_chi_score(observed, expected)
+      def self.test_of_independence_matr(alpha, observed_matr)
+        expected_matr = calculate_expected_matr(observed_matr)
+        df = (observed_matr.row_size - 1) * (observed_matr.column_size - 1)
+        chi_score = chi_statistic_matr(observed_matr, expected_matr)
         probability = 1.0 - Statistics::Distribution::ChiSquared.new(df).cumulative_function(chi_score)
         p_value = 1.0 - probability
     
@@ -60,34 +63,36 @@ module Statistics
           probability: probability,
           p_value: p_value,
           alpha: alpha,
-          #null: alpha < p_value,
-          #alternative: p_value <= alpha,
+          null: alpha < p_value,
+          alternative: p_value <= alpha,
           confidence_level: 1 - alpha,
-          expected: expected
+          expected: expected_matr
         }
       end
       
       # For a contingency table of observed values, calculate the expected values
-      def self.calculate_expected(observed)
-        row_sums = observed.map { |row| row.sum.to_f }
-        col_sums = observed.transpose.map { |col| col.sum.to_f }
+      def self.calculate_expected_matr(observed_matr)
+        row_sums = observed_matr.row_vectors.map { |row| row.to_a.sum.to_r }
+        col_sums = observed_matr.column_vectors.map { |col| col.to_a.sum.to_r }
         total_sum = row_sums.sum
-    
-        expected = observed.map.with_index { |row, i|
-          row.map.with_index { |obs, j|
-            (row_sums[i] * col_sums[j]) / total_sum
-          }
-        }
-        expected
+        
+        # create a mutable array from the Matrix of observed values
+        # so we have a 'template' for our Matrx of expected values
+        expected = observed_matr.to_a
+        # calculate the expected values
+        observed_matr.each_with_index do |i, row, col|
+          expected[row][col] = (row_sums[row] * col_sums[col]) / total_sum
+        end
+        Matrix.rows(expected)
       end
     
-      def self.calculate_chi_score(observed, expected)
+      private
+
+      def self.chi_statistic_matr(observed_matr, expected_matr)
         sum = 0.0
-        observed.size.times { |i|
-          observed[i].size.times { |j|
-            sum += ((observed[i])[j] - (expected[i])[j])**2 / (expected[i])[j]
-          }
-        }
+        observed_matr.each_with_index do |i, row, col|
+            sum += (observed_matr[row, col] - expected_matr[row, col])**2 / expected_matr[row, col]
+        end
         sum
       end
     end

--- a/lib/statistics/statistical_test/chi_squared_test.rb
+++ b/lib/statistics/statistical_test/chi_squared_test.rb
@@ -48,12 +48,12 @@ module Statistics
       # X   20  18
       # Y    7  35
       #
-      # They have been tested using 2x2 and 3x3 tables.
+      # They have been tested using 2x2 and 3x3 tables. Tables are implemented as type Matrix.
       #
-      def self.test_of_independence_matr(alpha, observed_matr)
-        expected_matr = calculate_expected_matr(observed_matr)
-        df = (observed_matr.row_size - 1) * (observed_matr.column_size - 1)
-        chi_score = chi_statistic_matr(observed_matr, expected_matr)
+      def self.test_of_independence(alpha, observed_matrix)
+        expected_matrix = calculate_expected_matrix(observed_matrix)
+        df = (observed_matrix.row_size - 1) * (observed_matrix.column_size - 1)
+        chi_score = chi_statistic_matrix(observed_matrix, expected_matrix)
         probability = 1.0 - Statistics::Distribution::ChiSquared.new(df).cumulative_function(chi_score)
         p_value = 1.0 - probability
     
@@ -66,35 +66,36 @@ module Statistics
           null: alpha < p_value,
           alternative: p_value <= alpha,
           confidence_level: 1 - alpha,
-          expected: expected_matr
+          expected: expected_matrix
         }
       end
       
       # For a contingency table of observed values, calculate the expected values
-      def self.calculate_expected_matr(observed_matr)
-        row_sums = observed_matr.row_vectors.map { |row| row.to_a.sum.to_r }
-        col_sums = observed_matr.column_vectors.map { |col| col.to_a.sum.to_r }
+      def self.calculate_expected_matrix(observed_matrix)
+        row_sums = observed_matrix.row_vectors.map { |row| row.to_a.sum.to_r }
+        col_sums = observed_matrix.column_vectors.map { |col| col.to_a.sum.to_r }
         total_sum = row_sums.sum
         
         # create a mutable array from the Matrix of observed values
         # so we have a 'template' for our Matrx of expected values
-        expected = observed_matr.to_a
+        expected = observed_matrix.to_a
         # calculate the expected values
-        observed_matr.each_with_index do |i, row, col|
+        observed_matrix.each_with_index do |i, row, col|
           expected[row][col] = (row_sums[row] * col_sums[col]) / total_sum
         end
         Matrix.rows(expected)
       end
-    
-      private
 
-      def self.chi_statistic_matr(observed_matr, expected_matr)
+      def self.chi_statistic_matrix(observed_matrix, expected_matrix)
         sum = 0.0
-        observed_matr.each_with_index do |i, row, col|
-            sum += (observed_matr[row, col] - expected_matr[row, col])**2 / expected_matr[row, col]
+        observed_matrix.each_with_index do |i, row, col|
+            sum += (observed_matrix[row, col] - expected_matrix[row, col])**2 / expected_matrix[row, col]
         end
         sum
       end
+
+      private_class_method :chi_statistic_matrix
+
     end
   end
 end

--- a/lib/statistics/statistical_test/chi_squared_test.rb
+++ b/lib/statistics/statistical_test/chi_squared_test.rb
@@ -37,6 +37,59 @@ module Statistics
           alternative: p_value <= alpha,
           confidence_level: 1 - alpha }
       end
+
+      # The following three functions serve to calculate a test of independence for contingency
+      # tables of the type
+      #
+      #      A   B
+      # X   20  18
+      # Y    7  35
+      #
+      # They have been tested using 2x2 and 3x3 tables.
+      #
+      def self.test_of_independence(alpha, observed)
+        expected = calculate_expected(observed)
+        df = (observed.size - 1) * (observed.transpose.size - 1)
+        chi_score = calculate_chi_score(observed, expected)
+        probability = 1.0 - Statistics::Distribution::ChiSquared.new(df).cumulative_function(chi_score)
+        p_value = 1.0 - probability
+    
+        {
+          chi_score: chi_score,
+          df: df,
+          probability: probability,
+          p_value: p_value,
+          alpha: alpha,
+          #null: alpha < p_value,
+          #alternative: p_value <= alpha,
+          confidence_level: 1 - alpha,
+          expected: expected
+        }
+      end
+      
+      # For a contingency table of observed values, calculate the expected values
+      def self.calculate_expected(observed)
+        row_sums = observed.map { |row| row.sum.to_f }
+        col_sums = observed.transpose.map { |col| col.sum.to_f }
+        total_sum = row_sums.sum
+    
+        expected = observed.map.with_index { |row, i|
+          row.map.with_index { |obs, j|
+            (row_sums[i] * col_sums[j]) / total_sum
+          }
+        }
+        expected
+      end
+    
+      def self.calculate_chi_score(observed, expected)
+        sum = 0.0
+        observed.size.times { |i|
+          observed[i].size.times { |j|
+            sum += ((observed[i])[j] - (expected[i])[j])**2 / (expected[i])[j]
+          }
+        }
+        sum
+      end
     end
   end
 end

--- a/lib/statistics/statistical_test/chi_squared_test.rb
+++ b/lib/statistics/statistical_test/chi_squared_test.rb
@@ -54,7 +54,7 @@ module Statistics
         expected_matrix = calculate_expected_matrix(observed_matrix)
         df = (observed_matrix.row_size - 1) * (observed_matrix.column_size - 1)
         chi_score = chi_statistic_matrix(observed_matrix, expected_matrix)
-        probability = 1.0 - Statistics::Distribution::ChiSquared.new(df).cumulative_function(chi_score)
+        probability = Statistics::Distribution::ChiSquared.new(df).cumulative_function(chi_score)
         p_value = 1.0 - probability
     
         {

--- a/ruby-statistics.gemspec
+++ b/ruby-statistics.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "statistics/version"
-require "matrix"
 
 Gem::Specification.new do |spec|
   spec.name          = "ruby-statistics"
@@ -33,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "grb", '~> 0.4.1', '>= 0.4.1'
   spec.add_development_dependency 'byebug', '>= 9.1.0'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'matrix'
 end

--- a/ruby-statistics.gemspec
+++ b/ruby-statistics.gemspec
@@ -2,6 +2,7 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "statistics/version"
+require "matrix"
 
 Gem::Specification.new do |spec|
   spec.name          = "ruby-statistics"

--- a/spec/statistics/statistical_test/chi_squared_test_spec.rb
+++ b/spec/statistics/statistical_test/chi_squared_test_spec.rb
@@ -84,30 +84,28 @@ describe Statistics::StatisticalTest::ChiSquaredTest do
     end
   end
 
-  describe '.calculate_expected_matr' do
+  describe '.calculate_expected_matrix' do
     
     it 'calculate expected values for a 2*3 contingency table of observed values' do
       
       observed = Matrix[[388,51692],[119,45633],[271,40040]]
-      expected = described_class.calculate_expected_matr(observed)
+      result = described_class.calculate_expected_matrix(observed)
 
-      expect(expected).to eq(Matrix[[(40518240/138143), (7153969200/138143)], [(35595056/138143), (6284723480/138143)], [(31361958/138143), (5537320515/138143)]])
+      expect(result).to eq(Matrix[[(40518240/138143), (7153969200/138143)], [(35595056/138143), (6284723480/138143)], [(31361958/138143), (5537320515/138143)]])
 
     end
 
   end
 
-  describe '.test_of_independence_matr' do
+  describe '.test_of_independence' do
 
     it 'calculate test of independence for a 2*3 contingency table' do
 
       observed = Matrix[[388,51692],[119,45633],[271,40040]]
       alpha = 0.05
 
-      result = {}
-
       expect do
-        result = described_class.test_of_independence_matr(alpha, observed)
+        result = described_class.test_of_independence(alpha, observed)
       end.not_to raise_error
 
       expect(result[:chi_score].round(4)).to eq(114.3600)

--- a/spec/statistics/statistical_test/chi_squared_test_spec.rb
+++ b/spec/statistics/statistical_test/chi_squared_test_spec.rb
@@ -91,7 +91,7 @@ describe Statistics::StatisticalTest::ChiSquaredTest do
       observed = Matrix[[388,51692],[119,45633],[271,40040]]
       result = described_class.calculate_expected_matrix(observed)
 
-      expect(result).to eq(Matrix[[(40518240/138143), (7153969200/138143)], [(35595056/138143), (6284723480/138143)], [(31361958/138143), (5537320515/138143)]])
+      expect(result.map(&:to_i)).to eq(Matrix[[(40518240/138143), (7153969200/138143)], [(35595056/138143), (6284723480/138143)], [(31361958/138143), (5537320515/138143)]])
 
     end
 
@@ -110,10 +110,10 @@ describe Statistics::StatisticalTest::ChiSquaredTest do
       end.not_to raise_error
 
       expect(result[:chi_score].round(4)).to eq(114.3600)
-      expect(result[:p_value].round(4)).to eq(1.4690)
+      expect(result[:p_value]).to eq(0.0)
       expect(result[:df]).to eq(2)
-      expect(result[:null]).to be true
-      expect(result[:alternative]).to be false
+      expect(result[:null]).to be false
+      expect(result[:alternative]).to be true
 
     end
 

--- a/spec/statistics/statistical_test/chi_squared_test_spec.rb
+++ b/spec/statistics/statistical_test/chi_squared_test_spec.rb
@@ -103,6 +103,7 @@ describe Statistics::StatisticalTest::ChiSquaredTest do
 
       observed = Matrix[[388,51692],[119,45633],[271,40040]]
       alpha = 0.05
+      result = {}
 
       expect do
         result = described_class.test_of_independence(alpha, observed)

--- a/spec/statistics/statistical_test/chi_squared_test_spec.rb
+++ b/spec/statistics/statistical_test/chi_squared_test_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'matrix'
 
 describe Statistics::StatisticalTest::ChiSquaredTest do
   describe '.chi_statistic' do
@@ -82,4 +83,42 @@ describe Statistics::StatisticalTest::ChiSquaredTest do
       expect(result[:alternative]).to be false
     end
   end
+
+  describe '.calculate_expected_matr' do
+    
+    it 'calculate expected values for a 2*3 contingency table of observed values' do
+      
+      observed = Matrix[[388,51692],[119,45633],[271,40040]]
+      expected = described_class.calculate_expected_matr(observed)
+
+      expect(expected).to eq(Matrix[[(40518240/138143), (7153969200/138143)], [(35595056/138143), (6284723480/138143)], [(31361958/138143), (5537320515/138143)]])
+
+    end
+
+  end
+
+  describe '.test_of_independence_matr' do
+
+    it 'calculate test of independence for a 2*3 contingency table' do
+
+      observed = Matrix[[388,51692],[119,45633],[271,40040]]
+      alpha = 0.05
+
+      result = {}
+
+      expect do
+        result = described_class.test_of_independence_matr(alpha, observed)
+      end.not_to raise_error
+
+      expect(result[:chi_score].round(4)).to eq(114.3600)
+      expect(result[:p_value].round(4)).to eq(1.4690)
+      expect(result[:df]).to eq(2)
+      expect(result[:null]).to be true
+      expect(result[:alternative]).to be false
+
+    end
+
+  end
+
+
 end


### PR DESCRIPTION
This adds tests for independence for so-called contingency tables, i.e. tables of 2*2, 2*3 etc. with observed values for nominal variables. The methods include calculating a table of expected values. Unit tests are included.