### PR TITLE
Remove obsolete standard deviation computation

### DIFF
--- a/lib/ruby-statistics/statistical_test/f_test.rb
+++ b/lib/ruby-statistics/statistical_test/f_test.rb
@@ -29,7 +29,6 @@ module RubyStatistics
 
           sample_sizes = args.map(&:size)
           sample_means = args.map(&:mean)
-          sample_stds = args.map(&:standard_deviation)
 
           # Variance between groups
           iterator = sample_sizes.each_with_index


### PR DESCRIPTION
The `sample_stds` variable is not used anywhere.
Looks like it can be simply removed.